### PR TITLE
chore: sync iOS and Android app versions with package.json

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -112,9 +112,10 @@ jobs:
 
       - name: Set CI app version
         run: |
+          APP_VERSION=$(node -p "require('./package.json').version")
           VERSION_OFFSET=2000
           echo "CI_VERSION_CODE=$(($VERSION_OFFSET + ${{ github.run_number }}))" >> $GITHUB_ENV
-          echo "CI_VERSION_NAME=1.0.${{ github.run_number }}" >> $GITHUB_ENV
+          echo "CI_VERSION_NAME=${APP_VERSION}.${{ github.run_number }}" >> $GITHUB_ENV
 
       - name: Set keystore env
         run: |

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -40,7 +40,12 @@ platform :ios do
     UI.message("🚀 Build scheme: #{scheme_name}")
     UI.message("🌐 API_BASE_URL: #{ENV['API_BASE_URL']}")
 
-    increment_version_number(version_number: "2.23")
+    require 'json'
+    package_json_path = File.expand_path("../../package.json", __dir__)
+    package_json = JSON.parse(File.read(package_json_path))
+    app_version = package_json["version"]
+
+    increment_version_number(version_number: app_version)
     increment_build_number(build_number: Time.now.strftime("%Y%m%d%H%M"))
 
     match(

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trioFrontendApp",
-  "version": "0.0.1",
+  "version": "3.0.0",
   "private": true,
   "scripts": {
     "android": "react-native run-android",


### PR DESCRIPTION
[빌드설정] 앱 버전 관리를 package.json 기준으로 통일
- 버전을 번거롭게 따로 올리지 않도록 양대 OS 모두 package.json을 읽어 배포되도록 수정