### PR TITLE
feat#323-알림-권한-요청

### DIFF
--- a/src/utils/fcmService.js
+++ b/src/utils/fcmService.js
@@ -1,4 +1,5 @@
 import messaging from '@react-native-firebase/messaging';
+import { Platform, PermissionsAndroid } from 'react-native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { v4 as uuidv4 } from 'uuid';
 import { log } from '@utils/logger';
@@ -20,8 +21,33 @@ export const getDeviceId = async () => {
   }
 };
 
+const requestAndroidNotificationPermission = async () => {
+  if (Platform.OS !== 'android' || Platform.Version < 33) {
+    return true;
+  }
+
+  try {
+    const granted = await PermissionsAndroid.request(
+      PermissionsAndroid.PERMISSIONS.POST_NOTIFICATIONS,
+    );
+    return granted === PermissionsAndroid.RESULTS.GRANTED;
+  } catch (error) {
+    log.error('Failed to request Android notification permission', error);
+    return false;
+  }
+};
+
 export const requestUserPermission = async () => {
   try {
+    const androidGranted = await requestAndroidNotificationPermission();
+    if (!androidGranted) {
+      return false;
+    }
+
+    if (Platform.OS === 'ios') {
+      await messaging().registerDeviceForRemoteMessages();
+    }
+
     const authStatus = await messaging().requestPermission();
     const enabled =
       authStatus === messaging.AuthorizationStatus.AUTHORIZED ||
@@ -50,9 +76,9 @@ export const syncFcmToken = async () => {
     }
 
     const deviceId = await getDeviceId();
-    
+
     log.info('📤 syncFcmToken:', { deviceId, fcmToken });
-    
+
     await notificationApi.registerToken(deviceId, fcmToken);
 
   } catch (error) {


### PR DESCRIPTION
###  알림 권한 요청 추가
HOST 앱과 동일하게 앱 실행 시, 알림 허용 요청 실행
거부 시, FCM 토큰 수집 불가 및 푸시 알림 불가능
