### PR TITLE
chore: 분리된 DEV/PROD 환경에 맞춰 Firebase CI/CD 배포 스크립트 분기 처리

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -107,7 +107,12 @@ jobs:
 
       - name: Decode Secrets (Keystore & Google Services)
         run: |
-          echo "${{ secrets.GOOGLE_SERVICES_JSON_BASE64 }}" | base64 --decode > android/app/google-services.json
+          BRANCH="${GITHUB_REF##*/}"
+          if [ "$BRANCH" = "develop" ]; then
+            echo "${{ secrets.GOOGLE_SERVICES_JSON_BASE64 }}" | base64 --decode > android/app/google-services.json
+          else
+            echo "${{ secrets.GOOGLE_SERVICES_JSON_PROD_BASE64 }}" | base64 --decode > android/app/google-services.json
+          fi
           echo "${{ secrets.KEYSTORE_BASE64 }}" | base64 --decode > android/app/test-release-key.jks
 
       - name: Set CI app version
@@ -117,9 +122,6 @@ jobs:
           echo "CI_VERSION_CODE=$(($VERSION_OFFSET + ${{ github.run_number }}))" >> $GITHUB_ENV
           echo "CI_VERSION_NAME=${APP_VERSION}.${{ github.run_number }}" >> $GITHUB_ENV
 
-      - name: Decode google-services.json
-        run: |
-          echo "${{ secrets.GOOGLE_SERVICES_JSON_BASE64 }}" | base64 --decode > android/app/google-services.json
 
       - name: Set keystore env
         run: |

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -150,7 +150,12 @@ jobs:
 
       - name: Decode GoogleService-Info.plist
         run: |
-          echo "${{ secrets.GOOGLE_SERVICE_INFO_PLIST_BASE64 }}" | base64 --decode > ios/GoogleService-Info.plist
+          BRANCH="${GITHUB_REF##*/}"
+          if [ "$BRANCH" = "develop" ]; then
+            echo "${{ secrets.GOOGLE_SERVICE_INFO_PLIST_BASE64 }}" | base64 --decode > ios/GoogleService-Info.plist
+          else
+            echo "${{ secrets.GOOGLE_SERVICE_INFO_PLIST_PROD_BASE64 }}" | base64 --decode > ios/GoogleService-Info.plist
+          fi
 
       # --------------------------------
       # Build & Upload


### PR DESCRIPTION
### 분리된 FCM 프로젝트 DEV/PROD 환경에 맞춰 Firebase CI/CD 배포 스크립트 분기 처리
1. Github Secret 값 추가 (PROD_BASE64)
2. 각 yml 파일 배포 스크립트 수정 - develop인 경우, 아닌 경우에 따라 호출 시크릿 값 분기 처리