### PR TITLE
feat(auth): 로그인, 회원가입 흐름 변경 (nice 부분 비활성화)

### DIFF
--- a/packages/app/src/components/Certificate/UserPhone.js
+++ b/packages/app/src/components/Certificate/UserPhone.js
@@ -17,7 +17,8 @@ import LogoOrange from '@assets/images/logo_orange.svg';
 import ButtonWhite from '@components/ButtonWhite';
 import AlertModal from '@components/modals/AlertModal';
 import Modal from '@components/modals/AdaptiveModal';
-import authApi from '@utils/api/authApi';
+// NICE 기반 본인인증 API는 백엔드에서 제거되어 비활성화됨.
+// import authApi from '@utils/api/authApi';
 import styles from './Certificate.styles';
 import {COLORS} from '@constants/colors';
 
@@ -83,19 +84,25 @@ const UserPhone = ({onPress}) => {
       setLoading(true);
 
       /**
+       * NICE 기반 본인인증은 백엔드에서 410 Gone으로 전환되어 호출하지 않음.
+       * 새 USER 가입/소셜 가입 플로우는 SMS 인증 컴포넌트로 교체 예정.
+       */
+      throw new Error('본인 인증 방식이 SMS 인증으로 변경되었습니다.');
+
+      /**
        * 서버에 init 요청
        * - POST /auth/nice/init
        * - 응답에 authUrl / requestNo / expiresAt 가 옴
        */
-      const res = await authApi.niceInit();
-      const {authUrl: nextAuthUrl} = res.data || {};
-
-      if (!nextAuthUrl) {
-        throw new Error('본인 인증 URL이 없습니다.');
-      }
-
-      setAuthUrl(nextAuthUrl);
-      setShowWebView(true);
+      // const res = await authApi.niceInit();
+      // const {authUrl: nextAuthUrl} = res.data || {};
+      //
+      // if (!nextAuthUrl) {
+      //   throw new Error('본인 인증 URL이 없습니다.');
+      // }
+      //
+      // setAuthUrl(nextAuthUrl);
+      // setShowWebView(true);
     } catch (error) {
       setErrorModal({
         visible: true,

--- a/packages/app/src/screens/(Common)/Login/LoginIntro/index.js
+++ b/packages/app/src/screens/(Common)/Login/LoginIntro/index.js
@@ -1,4 +1,4 @@
-import {Platform, View, TouchableOpacity, Text} from 'react-native';
+import {Platform, View} from 'react-native';
 import {useNavigation, CommonActions} from '@react-navigation/native';
 import React, {useState} from 'react';
 
@@ -8,7 +8,6 @@ import AlertModal from '@components/modals/AlertModal';
 import styles from './LoginIntro.styles';
 import KakaoLogo from '@assets/images/kakao_logo.svg';
 import MailGray from '@assets/images/mail_fill_gray.svg';
-import LogoWithText from '@assets/images/logo_orange_with_text.svg';
 import LogoIcon from '@assets/images/logo_orange.svg';
 import { COLORS } from '@constants/colors';
 
@@ -37,7 +36,9 @@ const LoginIntro = () => {
               params: {
                 user: 'USER',
                 isSocial: true,
-                externalId: result.externalId,
+                provider: result.provider,
+                socialSignupToken: result.socialSignupToken,
+                socialProfile: result.socialProfile,
               },
             },
           ],

--- a/packages/app/src/screens/(Common)/Login/SocialLogin/index.js
+++ b/packages/app/src/screens/(Common)/Login/SocialLogin/index.js
@@ -54,7 +54,9 @@ const SocialLogin = () => {
   };
 
   const handleLoginByCode = async code => {
-    if (!code || isSubmitting) return;
+    if (!code || isSubmitting) {
+      return;
+    }
 
     setIsSubmitting(true);
 
@@ -74,8 +76,8 @@ const SocialLogin = () => {
 
       // 신규 유저
       if (data.isNewUser) {
-        if (!data.externalId) {
-          openError('신규 유저 식별값이 없음', () =>
+        if (!data.socialSignupToken) {
+          openError('소셜 가입 세션이 없음', () =>
             navigation.reset({
               index: 0,
               routes: [{name: 'LoginIntro'}],
@@ -91,7 +93,15 @@ const SocialLogin = () => {
               params: {
                 user: 'USER',
                 isSocial: true,
-                externalId: data.externalId,
+                provider,
+                socialSignupToken: data.socialSignupToken,
+                socialProfile: data.profile || data.socialProfile || {
+                  email: data.email || '',
+                  nickname: data.nickname || '',
+                  name: data.name || '',
+                  birthday: data.birthday || '',
+                  gender: data.gender || '',
+                },
               },
             },
           ],

--- a/packages/app/src/screens/(Common)/Login/VerifyPhone/index.js
+++ b/packages/app/src/screens/(Common)/Login/VerifyPhone/index.js
@@ -21,6 +21,7 @@ import LogoOrange from '@assets/images/logo_orange.svg';
 const VerifyPhone = ({route}) => {
   const {find, originPhone} = route.params;
   const userRole = 'USER';
+  const smsPurpose = 'FIND_ACCOUNT';
   const navigation = useNavigation();
   const [phoneNumber, setPhoneNumber] = useState('');
   const [isPhoneNumberValid, setIsPhoneNumberValid] = useState(false);
@@ -124,7 +125,7 @@ const VerifyPhone = ({route}) => {
       }
     }
     try {
-      await authApi.verifySelfByPhone(phoneNumber, userRole);
+      await authApi.sendSms(phoneNumber, userRole, smsPurpose);
       setHasRequestedCode(true);
       setIsCodeSent(true);
       setTimeLeft(300);
@@ -159,7 +160,7 @@ const VerifyPhone = ({route}) => {
   const verifyCode = async () => {
     setLoading(true);
     try {
-      await authApi.verifySms(phoneNumber, code);
+      await authApi.verifySms(phoneNumber, code, userRole, smsPurpose);
       setIsTimerActive(false);
       setIsCodeVerified(true);
     } catch (error) {
@@ -277,14 +278,14 @@ const VerifyPhone = ({route}) => {
               {loading ? (
                 <ButtonScarletLogo disabled={true} />
               ) : isCodeVerified ? (
-                <ButtonWhite 
+                <ButtonWhite
                   title="인증 성공!"
                   backgroundColor={mainColor}
                   textColor={COLORS.grayscale_0}
                 />
               ) : isCodeValid ? (
-                <ButtonWhite 
-                  title="인증하기" 
+                <ButtonWhite
+                  title="인증하기"
                   onPress={verifyCode}
                   backgroundColor={mainColor}
                   textColor={COLORS.grayscale_0}

--- a/packages/app/src/screens/(Common)/Register/PhoneCertificate/index.js
+++ b/packages/app/src/screens/(Common)/Register/PhoneCertificate/index.js
@@ -1,244 +1,487 @@
-  import React, {useState} from 'react';
-  import {useNavigation} from '@react-navigation/native';
-  import Toast from 'react-native-toast-message';
+import React, {useCallback, useEffect, useState} from 'react';
+import {
+  Keyboard,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  TouchableWithoutFeedback,
+  View,
+} from 'react-native';
+import {
+  CommonActions,
+  useFocusEffect,
+  useNavigation,
+} from '@react-navigation/native';
 
-  import UserPhone from '@components/Certificate/UserPhone';
-  import useUserStore from '@stores/userStore';
-  import authApi from '@utils/api/authApi';
-  import {storeLoginTokens} from '@utils/auth/login';
+import ButtonScarletLogo from '@components/ButtonScarletLogo';
+import ButtonWhite from '@components/ButtonWhite';
+import AlertModal from '@components/modals/AlertModal';
+import LogoOrange from '@assets/images/logo_orange.svg';
+import {COLORS} from '@constants/colors';
+import authApi from '@utils/api/authApi';
+import {storeLoginTokens} from '@utils/auth/login';
 
-  import AlertModal from '@components/modals/AlertModal';
+import styles from '../../Login/Login.styles';
 
-  /**
-   * PhoneCertificate 역할
-   * - USER: NICE(UserPhone) 인증 → niceAuthToken 받기 → check-status 호출 → 다음 화면 이동
-   */
-  const PhoneCertificate = ({route}) => {
-    const {user, agreements, email, isSocial = false, externalId = null, isUpdateCi = false} =
-      route.params;
-    const navigation = useNavigation();
-    const [checking, setChecking] = useState(false); // 중복 호출 방지
+/**
+ * NICE 기반 USER 본인인증/가입 보조 경로는 백엔드에서 제거되어 비활성화함.
+ *
+ * 기존 흐름 요약:
+ * - <UserPhone />에서 POST /auth/nice/init 호출
+ * - NICE WebView 완료 후 niceAuthToken 수신
+ * - authApi.checkSignUpStatus(niceAuthToken)
+ * - authApi.completeUserSignUp({niceAuthToken, ...})
+ *
+ * 현재 일반 USER 가입 흐름:
+ * - 이메일 인증 완료
+ * - SMS 인증 USER + SIGN_UP 완료
+ * - UserRegisterProfile에서 /auth/user/signup 호출
+ */
+const PhoneCertificate = ({route}) => {
+  const {
+    user = 'USER',
+    agreements = [],
+    email = '',
+    isSocial = false,
+    socialSignupToken = null,
+    provider = null,
+    socialProfile = {},
+  } = route.params || {};
+  const userRole = user || 'USER';
+  const navigation = useNavigation();
 
-    const [errorModal, setErrorModal] = useState({
-      visible: false,
-      message: '',
-      buttonText: '확인',
-      onPress: null,
+  const [smsPurpose, setSmsPurpose] = useState('SIGN_UP');
+  const [phoneNumber, setPhoneNumber] = useState('');
+  const [isPhoneNumberValid, setIsPhoneNumberValid] = useState(false);
+  const [code, setCode] = useState('');
+  const [isCodeValid, setIsCodeValid] = useState(false);
+  const [isCodeSent, setIsCodeSent] = useState(false);
+  const [isCodeVerified, setIsCodeVerified] = useState(false);
+  const [timeLeft, setTimeLeft] = useState(300);
+  const [isTimerActive, setIsTimerActive] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [hasRequestedCode, setHasRequestedCode] = useState(false);
+  const [isResendEnabled, setIsResendEnabled] = useState(false);
+  const [errorModal, setErrorModal] = useState({
+    visible: false,
+    message: '',
+    buttonText: '',
+    onPress: null,
+  });
+
+  const MainLogo = LogoOrange;
+  const mainColor = COLORS.primary_orange;
+  const socialProfileEmail = socialProfile.email || '';
+  const socialProfileName = socialProfile.name || '';
+  const socialProfileBirthday = socialProfile.birthday || '';
+  const socialProfileGender = socialProfile.gender || '';
+  const socialProfileNickname = socialProfile.nickname || '';
+  const hasCompleteSocialProfile =
+    !!socialProfileName &&
+    /^\d{4}-\d{2}-\d{2}$/.test(socialProfileBirthday) &&
+    (socialProfileGender === 'M' || socialProfileGender === 'F') &&
+    !!socialProfileNickname;
+
+  const moveToSocialProfileFallback = useCallback(() => {
+    navigation.navigate('UserRegisterProfile', {
+      prevData: {
+        userRole,
+        agreements,
+        email: email || socialProfileEmail,
+        phoneNum: phoneNumber,
+        isSocial,
+        socialSignupToken,
+        provider,
+        name: socialProfileName,
+        birthday: socialProfileBirthday,
+        gender: socialProfileGender,
+        nickname: socialProfileNickname,
+        password: '',
+        passwordConfirm: '',
+      },
     });
+  }, [
+    agreements,
+    email,
+    isSocial,
+    navigation,
+    phoneNumber,
+    provider,
+    socialProfileBirthday,
+    socialProfileEmail,
+    socialProfileGender,
+    socialProfileName,
+    socialProfileNickname,
+    socialSignupToken,
+    userRole,
+  ]);
 
-    const openModal = ({message, buttonText = '확인', onPress = null}) => {
-      setErrorModal({
-        visible: true,
-        message,
-        buttonText,
-        onPress,
-      });
-    };
-
-    const closeModal = () => {
-      setErrorModal(prev => ({...prev, visible: false}));
-    };
-
-    const moveToLoginIntro = () => {
-      closeModal();
-      navigation.reset({
-        index: 0,
-        routes: [{name: 'LoginIntro'}],
-      });
-    };
-
-    /**
-     * NICE 인증 완료 토큰을 받았을 때 실행되는 콜백
-     * - token은 일회용/유효시간(10분)
-     */
-    const getErrorMessage = error =>
-      error?.response?.data?.message ||
-      error?.message ||
-      '계정 상태 확인 중 문제가 발생했어요.';
-
-    const handleNiceVerifiedSuccess = async niceAuthToken => {
-      // 토큰이 없으면 아무 것도 안함
-      if (!niceAuthToken) return;
-
-      // 중복 방지
-      if (checking) return;
-
-      try {
-        setChecking(true);
-
-  if (isUpdateCi) {
-          try {
-            // 1. 서버에 CI 매핑 요청
-            await authApi.verifyCi(niceAuthToken);
-            
-            Toast.show({
-              type: 'success',
-              text1: '본인 인증이 완료되었습니다!',
-              position: 'top',
-            });
-            
-            useUserStore.getState().setIsVerified(true);
-            
-            // 2. 인증이 완료되었으므로 메인으로 이동
-            navigation.reset({
-              index: 0,
-              routes: [{name: 'MainTabs'}],
-            });
-            return;
-          } catch (error) {
-            openModal({
-              message: error?.response?.data?.message || '인증 정보 업데이트에 실패했습니다.',
-              buttonText: '확인',
-              onPress: () => navigation.goBack(),
-            });
-            return;
-          }
-        }
-
-        if (isSocial && !externalId) {
-          openModal({
-            message: '로그인 오류 잠시 후 다시 시도해주세요.',
-            buttonText: '로그인으로 이동',
-            onPress: moveToLoginIntro,
-          });
-          return;
-        }
-
-        if (isSocial && externalId) {
-          let res;
-          try {
-            res = await authApi.completeSocialSignUp({
-              externalId,
-              niceAuthToken,
-              userRole: 'USER',
-              agreements: agreements || [],
-            });
-          } catch (error) {
-            openModal({
-              message: getErrorMessage(error),
-              buttonText: '로그인으로 이동',
-              onPress: moveToLoginIntro,
-            });
-            return;
-          }
-
-          const {accessToken, refreshToken} = res.data || {};
-
-          if (!accessToken || !refreshToken) {
-            openModal({
-              message: getErrorMessage(),
-              buttonText: '로그인으로 이동',
-              onPress: moveToLoginIntro,
-            });
-            return;
-          }
-
-          await storeLoginTokens({
-            accessToken,
-            refreshToken,
-            userRole: 'USER',
-          });
-
-          navigation.reset({
-            index: 0,
-            routes: [{name: 'MainTabs'}],
-          });
-          return;
-        }
-
-        // 가입 상태 체크
-        const res = await authApi.checkSignUpStatus(niceAuthToken);
-        const {status, socialTypes, message} = res.data;
-
-        if (!status) {
-          openModal({
-            message: '계정 상태 확인 중 문제가 발생했어요.',
-          });
-          return;
-        }
-
-        // NEW_USER: 신규 회원 → 가입폼으로 이동
-        if (status === 'NEW_USER') {
-          Toast.show({
-            type: 'success',
-            text1: '인증이 완료되었어요!',
-            position: 'top',
-            visibilityTime: 2000,
-          });
-
-          navigation.navigate('UserRegisterProfile', {
-            prevData: {
-              userRole: 'USER',
-              agreements: agreements || [],
-              email: email || '',
-              niceAuthToken,
-              nickname: '',
-              password: '',
-              passwordConfirm: '',
-            },
-          });
-          return;
-        }
-
-        // ALREADY_LOCAL: 이미 로컬 계정 존재 → 로그인 유도
-        if (status === 'ALREADY_LOCAL') {
-          openModal({
-            message:
-              message || '해당 명의로 이미 가입된 계정이 있어요.',
-            buttonText: '로그인으로 이동',
-            onPress: () => {
-              closeModal();
-              navigation.navigate('LoginIntro');
-            },
-          });
-          return;
-        }
-
-        // SOCIAL_INTEGRATION: 소셜 계정 존재 → 연동 내역 + 가입폼 이동
-        if (status === 'SOCIAL_INTEGRATION') {
-          Toast.show({
-            type: 'success',
-            text1: '인증이 완료되었어요!',
-            position: 'top',
-            visibilityTime: 2000,
-          });
-
-          navigation.navigate('UserRegisterProfile', {
-            prevData: {
-              userRole: 'USER',
-              agreements: agreements || [],
-              email: email || '',
-              niceAuthToken,
-              isIntegration: true,
-              socialTypes: socialTypes || [],
-              nickname: '',
-              password: '',
-              passwordConfirm: '',
-            },
-          });
-
-          return;
-        }
-
-        // 알 수 없는 status
-        openModal({
-          message: getErrorMessage(),
-        });
-      } catch (e) {
-        openModal({
-          message: getErrorMessage(e),
-          ...(isSocial
-            ? {buttonText: '로그인으로 이동', onPress: moveToLoginIntro}
-            : null),
-        });
-      } finally {
-        setChecking(false);
-      }
-    };
+  const isSocialProfileCompletionError = error => {
+    const data = error?.response?.data;
+    const errorCode = data?.code || data?.errorCode || data?.status || '';
+    const message = data?.message || error?.message || '';
 
     return (
-      <>
-        <UserPhone user={user} onPress={handleNiceVerifiedSuccess} />
+      errorCode.includes('NICKNAME') ||
+      errorCode.includes('PROFILE') ||
+      errorCode.includes('REQUIRED') ||
+      message.includes('닉네임') ||
+      message.includes('필수') ||
+      message.includes('중복')
+    );
+  };
+
+  const completeSocialSignUp = useCallback(async () => {
+    try {
+      setLoading(true);
+
+      const res = await authApi.completeSocialSignUp({
+        provider,
+        socialSignupToken,
+        userRole,
+        phoneNum: phoneNumber,
+        name: socialProfileName,
+        birthday: socialProfileBirthday,
+        gender: socialProfileGender,
+        nickname: socialProfileNickname,
+        agreements,
+      });
+
+      const {accessToken, refreshToken} = res.data || {};
+
+      if (!accessToken || !refreshToken) {
+        throw new Error('소셜 회원가입 토큰 응답이 비어있습니다.');
+      }
+
+      await storeLoginTokens({
+        accessToken,
+        refreshToken,
+        userRole,
+      });
+
+      navigation.dispatch(
+        CommonActions.reset({
+          index: 0,
+          routes: [{name: 'MainTabs', params: {screen: '홈'}}],
+        }),
+      );
+    } catch (error) {
+      if (isSocialProfileCompletionError(error)) {
+        setErrorModal({
+          visible: true,
+          message:
+            error?.response?.data?.message ||
+            '카카오에서 받은 정보를 확인해주세요.',
+          buttonText: '확인',
+          onPress: moveToSocialProfileFallback,
+        });
+        return;
+      }
+
+      setErrorModal({
+        visible: true,
+        message:
+          error?.response?.data?.message ||
+          error?.message ||
+          '소셜 회원가입에 실패했습니다.',
+        buttonText: '확인',
+        onPress: null,
+      });
+    } finally {
+      setLoading(false);
+    }
+  }, [
+    agreements,
+    navigation,
+    phoneNumber,
+    provider,
+    moveToSocialProfileFallback,
+    socialProfileBirthday,
+    socialProfileGender,
+    socialProfileName,
+    socialProfileNickname,
+    socialSignupToken,
+    userRole,
+  ]);
+
+  useFocusEffect(
+    useCallback(() => {
+      setPhoneNumber('');
+      setIsPhoneNumberValid(false);
+      setCode('');
+      setIsCodeValid(false);
+      setIsCodeSent(false);
+      setIsCodeVerified(false);
+      setTimeLeft(300);
+      setIsTimerActive(false);
+      setLoading(false);
+      setHasRequestedCode(false);
+      setIsResendEnabled(false);
+      setSmsPurpose('SIGN_UP');
+      setErrorModal({
+        visible: false,
+        message: '',
+        buttonText: '',
+        onPress: null,
+      });
+    }, []),
+  );
+
+  useEffect(() => {
+    setIsPhoneNumberValid(phoneNumber.length === 11);
+  }, [phoneNumber]);
+
+  useEffect(() => {
+    setIsCodeValid(code.length === 6);
+  }, [code]);
+
+  useEffect(() => {
+    if (!isCodeVerified) {
+      return undefined;
+    }
+
+    const timeoutId = setTimeout(() => {
+      if (isSocial && hasCompleteSocialProfile) {
+        completeSocialSignUp();
+        return;
+      }
+
+      moveToSocialProfileFallback();
+    }, 850);
+
+    return () => clearTimeout(timeoutId);
+  }, [
+    agreements,
+    completeSocialSignUp,
+    hasCompleteSocialProfile,
+    email,
+    isCodeVerified,
+    isSocial,
+    moveToSocialProfileFallback,
+    socialSignupToken,
+    userRole,
+  ]);
+
+  useEffect(() => {
+    let interval = null;
+    if (isTimerActive && timeLeft > 0) {
+      interval = setInterval(() => {
+        setTimeLeft(prev => prev - 1);
+      }, 1000);
+    } else if (timeLeft === 0) {
+      clearInterval(interval);
+      setIsTimerActive(false);
+      setErrorModal({
+        visible: true,
+        message: '인증 유효 시간이 만료되었습니다.',
+        buttonText: '확인',
+      });
+    }
+
+    return () => clearInterval(interval);
+  }, [isTimerActive, timeLeft]);
+
+  const openPhoneAlreadyExistsForSocial = () => {
+    setErrorModal({
+      visible: true,
+      message:
+        '이미 가입된 전화번호입니다.\n기존 계정에 소셜 계정을 연결하려면 인증을 진행해주세요.',
+      buttonText: '연동 인증하기',
+      onPress: async () => {
+        setErrorModal(prev => ({...prev, visible: false, onPress: null}));
+        setSmsPurpose('FIND_ACCOUNT');
+        await sendVerificationCode('FIND_ACCOUNT');
+      },
+    });
+  };
+
+  const isPhoneAlreadyExistsError = error => {
+    const data = error?.response?.data;
+    const errorCode = data?.code || data?.errorCode || data?.status;
+    const message = data?.message || '';
+    return (
+      errorCode === 'PHONE_ALREADY_EXISTS' || message.includes('이미 가입')
+    );
+  };
+
+  const sendVerificationCode = async (purpose = smsPurpose) => {
+    try {
+      await authApi.sendSms(phoneNumber, userRole, purpose);
+      setHasRequestedCode(true);
+      setIsCodeSent(true);
+      setTimeLeft(300);
+      setIsTimerActive(true);
+
+      setErrorModal({
+        visible: true,
+        message: `${phoneNumber}으로\n인증 번호가 발송 되었습니다`,
+        buttonText: '확인',
+      });
+
+      setIsResendEnabled(false);
+      setTimeout(() => setIsResendEnabled(true), 30000);
+    } catch (error) {
+      if (
+        isSocial &&
+        purpose === 'SIGN_UP' &&
+        isPhoneAlreadyExistsError(error)
+      ) {
+        openPhoneAlreadyExistsForSocial();
+        return;
+      }
+
+      setErrorModal({
+        visible: true,
+        message:
+          error?.response?.data?.message || '인증번호 전송에 실패했습니다',
+        buttonText: '확인',
+        onPress: null,
+      });
+    }
+  };
+
+  const resendVerificationCode = () => {
+    setCode('');
+    sendVerificationCode();
+  };
+
+  const verifyCode = async () => {
+    setLoading(true);
+    try {
+      await authApi.verifySms(phoneNumber, code, userRole, smsPurpose);
+      setIsTimerActive(false);
+      setIsCodeVerified(true);
+    } catch (error) {
+      setErrorModal({
+        visible: true,
+        message: error?.response?.data?.message || '인증에 실패했습니다.',
+        buttonText: '다시 인증하기',
+      });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const formatTime = seconds => {
+    const mins = Math.floor(seconds / 60);
+    const secs = seconds % 60;
+    return `0${mins}:${secs < 10 ? '0' : ''}${secs}`;
+  };
+
+  return (
+    <TouchableWithoutFeedback onPress={Keyboard.dismiss} accessible={false}>
+      <View style={styles.container}>
+        <View style={styles.viewFlexBox}>
+          <View>
+            <View style={styles.groupParent}>
+              <View style={styles.titleContainer}>
+                <MainLogo width={60} height={29} />
+              </View>
+              <Text style={styles.titleText}>전화번호 인증</Text>
+            </View>
+
+            <View style={styles.inputGroup}>
+              <View style={styles.inputContainer}>
+                <Text style={styles.inputLabel}>전화번호</Text>
+                <View style={styles.inputBox}>
+                  <TextInput
+                    style={styles.textInput}
+                    placeholder="전화번호를 입력해주세요"
+                    placeholderTextColor={COLORS.grayscale_400}
+                    value={phoneNumber}
+                    onChangeText={text => {
+                      const filtered = text.replace(/[^0-9]/g, '');
+                      setPhoneNumber(filtered);
+                      setHasRequestedCode(false);
+                      setIsCodeSent(false);
+                      setIsResendEnabled(false);
+                      setSmsPurpose('SIGN_UP');
+                    }}
+                    keyboardType="number-pad"
+                    maxLength={11}
+                  />
+                  <TouchableOpacity
+                    onPress={sendVerificationCode}
+                    disabled={!isPhoneNumberValid || hasRequestedCode}>
+                    <Text
+                      style={[
+                        styles.inputButton,
+                        isPhoneNumberValid && !hasRequestedCode
+                          ? {color: COLORS.primary_orange}
+                          : '',
+                      ]}>
+                      인증요청
+                    </Text>
+                  </TouchableOpacity>
+                </View>
+              </View>
+
+              <View style={styles.inputContainer}>
+                <Text style={styles.inputLabel}>인증번호</Text>
+                <View style={styles.inputBox}>
+                  <TextInput
+                    style={styles.textInput}
+                    placeholder="인증번호를 입력해주세요"
+                    placeholderTextColor={COLORS.grayscale_400}
+                    value={code}
+                    onChangeText={text => {
+                      const filtered = text.replace(/[^0-9]/g, '');
+                      setCode(filtered);
+                    }}
+                    keyboardType="number-pad"
+                    maxLength={6}
+                    editable={isCodeSent}
+                  />
+                  <Text
+                    style={[
+                      styles.inputButton,
+                      isCodeSent ? {color: COLORS.primary_orange} : '',
+                    ]}>
+                    {isCodeSent ? formatTime(timeLeft) : '00:00'}
+                  </Text>
+                </View>
+                <View style={styles.resendContainer}>
+                  <TouchableOpacity
+                    onPress={resendVerificationCode}
+                    disabled={!hasRequestedCode || !isResendEnabled}>
+                    <Text
+                      style={[
+                        styles.resendText,
+                        hasRequestedCode && isResendEnabled
+                          ? {color: COLORS.primary_orange}
+                          : '',
+                      ]}>
+                      인증번호 재전송
+                    </Text>
+                  </TouchableOpacity>
+                </View>
+              </View>
+            </View>
+          </View>
+
+          <View style={styles.frameParent}>
+            <View style={styles.frameGroup}>
+              {loading ? (
+                <ButtonScarletLogo disabled={true} />
+              ) : isCodeVerified ? (
+                <ButtonWhite
+                  title="인증 성공!"
+                  backgroundColor={mainColor}
+                  textColor={COLORS.grayscale_0}
+                />
+              ) : isCodeValid ? (
+                <ButtonWhite
+                  title="인증하기"
+                  onPress={verifyCode}
+                  backgroundColor={mainColor}
+                  textColor={COLORS.grayscale_0}
+                />
+              ) : (
+                <ButtonWhite title="인증하기" disabled={true} />
+              )}
+            </View>
+          </View>
+        </View>
 
         <AlertModal
           visible={errorModal.visible}
@@ -249,11 +492,12 @@
               errorModal.onPress();
               return;
             }
-            closeModal();
+            setErrorModal(prev => ({...prev, visible: false}));
           }}
         />
-      </>
-    );
-  };
+      </View>
+    </TouchableWithoutFeedback>
+  );
+};
 
-  export default PhoneCertificate;
+export default PhoneCertificate;

--- a/packages/app/src/screens/(Common)/Register/RegisterAgree/index.js
+++ b/packages/app/src/screens/(Common)/Register/RegisterAgree/index.js
@@ -2,7 +2,6 @@ import React, {useState, useEffect} from 'react';
 import {Text, View, TouchableOpacity} from 'react-native';
 import {useNavigation} from '@react-navigation/native';
 
-import ButtonScarlet from '@components/ButtonScarlet';
 import {userRegisterAgrees} from '@data/agree';
 import ButtonWhite from '@components/ButtonWhite';
 
@@ -13,7 +12,13 @@ import styles from './Agree.styles';
 import { COLORS } from '@constants/colors';
 
 const RegisterAgree = ({route}) => {
-  const {user, isSocial = false, externalId = null} = route.params;
+  const {
+    user,
+    isSocial = false,
+    provider = null,
+    socialSignupToken = null,
+    socialProfile = {},
+  } = route.params;
   const [agreements, setAgreements] = useState(userRegisterAgrees);
   const [isAllAgreed, setIsAllAgreed] = useState(false);
   const [isRequiredAgreed, setIsRequiredAgreed] = useState(false);
@@ -66,7 +71,9 @@ const RegisterAgree = ({route}) => {
         user,
         agreements: agreementPayload,
         isSocial: true,
-        externalId,
+        provider,
+        socialSignupToken,
+        socialProfile,
       });
       return;
     }
@@ -146,9 +153,9 @@ const RegisterAgree = ({route}) => {
             ))}
           </View>
           {isRequiredAgreed ? (
-            <ButtonWhite 
-              title="다음" 
-              onPress={handleMoveNext} 
+            <ButtonWhite
+              title="다음"
+              onPress={handleMoveNext}
               backgroundColor={mainColor}
               textColor={COLORS.grayscale_0}
             />

--- a/packages/app/src/screens/(User)/UserRegister/UserRegisterProfile/UserRegisterProfile.styles.js
+++ b/packages/app/src/screens/(User)/UserRegister/UserRegisterProfile/UserRegisterProfile.styles.js
@@ -92,6 +92,31 @@ export default StyleSheet.create({
     paddingHorizontal: 12,
     paddingVertical: 8,
   },
+  genderGroup: {
+    flexDirection: 'row',
+    gap: 8,
+  },
+  genderButton: {
+    flex: 1,
+    height: 44,
+    borderRadius: 20,
+    borderWidth: 1,
+    borderColor: COLORS.grayscale_200,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: COLORS.grayscale_0,
+  },
+  genderButtonActive: {
+    borderColor: COLORS.primary_orange,
+    backgroundColor: COLORS.primary_orange,
+  },
+  genderButtonText: {
+    ...FONTS.fs_14_medium,
+    color: COLORS.grayscale_400,
+  },
+  genderButtonTextActive: {
+    color: COLORS.grayscale_0,
+  },
   resendText: {...FONTS.fs_12_medium, color: COLORS.grayscale_400},
   resendContainer: {
     textAlign: 'right',

--- a/packages/app/src/screens/(User)/UserRegister/UserRegisterProfile/index.js
+++ b/packages/app/src/screens/(User)/UserRegister/UserRegisterProfile/index.js
@@ -19,7 +19,7 @@ import authApi from '@utils/api/authApi';
 import ButtonScarlet from '@components/ButtonScarlet';
 import {validateRegisterProfile} from '@utils/validation/registerValidation';
 import AlertModal from '@components/modals/AlertModal';
-import {tryLogin} from '@utils/auth/login';
+import {storeLoginTokens, tryLogin} from '@utils/auth/login';
 import useKeyboardAwareScrollView from '@hooks/useKeyboardAwareScrollView';
 
 import styles from './UserRegisterProfile.styles';
@@ -34,6 +34,7 @@ const UserRegisterProfile = () => {
   const {prevData} = route.params;
   const navigation = useNavigation();
   const [formData, setFormData] = useState(prevData);
+  const isSocialSignUp = !!formData?.isSocial;
   const [formValid, setFormValid] = useState({
     nickname: [],
     password: [],
@@ -65,6 +66,8 @@ const UserRegisterProfile = () => {
   const nicknameField = registerInput('nickname');
   const passwordField = registerInput('password');
   const passwordConfirmField = registerInput('passwordConfirm');
+  const nameField = registerInput('name');
+  const birthdayField = registerInput('birthday');
 
   useEffect(() => {
     if (pendingAfterLogin) {
@@ -75,7 +78,6 @@ const UserRegisterProfile = () => {
 
   useFocusEffect(
     useCallback(() => {
-      console.log(prevData);
       setFormData(prevData);
       setFormValid({
         nickname: [],
@@ -107,6 +109,22 @@ const UserRegisterProfile = () => {
       nickname: validateRegisterProfile({...formData, nickname: text}).nickname,
     };
     setFormValid(nextValid);
+  };
+
+  const handleNameChange = text => {
+    updateField('name', text);
+  };
+
+  const handleBirthdayChange = text => {
+    const filtered = text.replace(/[^0-9]/g, '').slice(0, 8);
+    const formatted = filtered
+      .replace(/^(\d{4})(\d)/, '$1-$2')
+      .replace(/^(\d{4}-\d{2})(\d)/, '$1-$2');
+    updateField('birthday', formatted);
+  };
+
+  const handleGenderChange = gender => {
+    updateField('gender', gender);
   };
 
   const handlePasswordChange = text => {
@@ -168,21 +186,75 @@ const UserRegisterProfile = () => {
 
     const confirmValid = formValid.passwordConfirm?.isMatched;
 
+    if (isSocialSignUp) {
+      const nameValid = !!formData.name?.trim();
+      const birthdayValid = /^\d{4}-\d{2}-\d{2}$/.test(
+        formData.birthday || '',
+      );
+      const genderValid = formData.gender === 'M' || formData.gender === 'F';
+
+      return nicknameValid && nameValid && birthdayValid && genderValid;
+    }
+
     return nicknameValid && passwordValid && confirmValid;
   };
 
   const handleSubmit = async () => {
     try {
+      if (isSocialSignUp) {
+        const payload = {
+          provider: formData.provider,
+          socialSignupToken: formData.socialSignupToken,
+          userRole: formData.userRole,
+          phoneNum: formData.phoneNum,
+          name: formData.name,
+          birthday: formData.birthday,
+          gender: formData.gender,
+          nickname: formData.nickname,
+          agreements: formData.agreements,
+        };
+
+        const res = await authApi.completeSocialSignUp(payload);
+        const {accessToken, refreshToken} = res.data || {};
+
+        if (!accessToken || !refreshToken) {
+          throw new Error('소셜 회원가입 토큰 응답이 비어있습니다.');
+        }
+
+        await storeLoginTokens({
+          accessToken,
+          refreshToken,
+          userRole: 'USER',
+        });
+
+        navigation.dispatch(
+          CommonActions.reset({
+            index: 0,
+            routes: [{name: 'MainTabs', params: {screen: '홈'}}],
+          }),
+        );
+        return;
+      }
+
       const payload = {
-        niceAuthToken: formData.niceAuthToken,
         email: formData.email,
         password: formData.password,
         passwordConfirm: formData.passwordConfirm,
         nickname: formData.nickname,
         userRole: formData.userRole,
+        phoneNum: formData.phoneNum,
         agreements: formData.agreements,
       };
-      await authApi.completeUserSignUp(payload);
+
+      /**
+       * 기존 NICE 기반 가입 완료:
+       * - niceAuthToken을 /auth/user/signup/complete로 전달
+       *
+       * 새 일반 USER 가입:
+       * - PhoneCertificate에서 SMS USER + SIGN_UP 인증 완료
+       * - phoneNum을 /auth/user/signup으로 전달
+       */
+      await authApi.userSignUp(payload);
       afterSuccessRegister();
     } catch (error) {
       setErrorModal({
@@ -280,6 +352,83 @@ const UserRegisterProfile = () => {
               </View>
             </View>
             <View style={styles.inputGroup}>
+              {isSocialSignUp && (
+                <>
+                  <View
+                    style={styles.inputContainer}
+                    onLayout={nameField.onLayout}>
+                    <Text style={styles.inputLabel}>이름</Text>
+                    <View style={styles.inputBox}>
+                      <TextInput
+                        style={styles.textInput}
+                        placeholder="이름을 입력해주세요"
+                        placeholderTextColor={COLORS.grayscale_400}
+                        value={formData.name}
+                        onChangeText={handleNameChange}
+                        onFocus={nameField.onFocus}
+                        maxLength={20}
+                      />
+                    </View>
+                  </View>
+
+                  <View
+                    style={styles.inputContainer}
+                    onLayout={birthdayField.onLayout}>
+                    <Text style={styles.inputLabel}>생년월일</Text>
+                    <View style={styles.inputBox}>
+                      <TextInput
+                        style={styles.textInput}
+                        placeholder="YYYY-MM-DD"
+                        placeholderTextColor={COLORS.grayscale_400}
+                        value={formData.birthday}
+                        onChangeText={handleBirthdayChange}
+                        onFocus={birthdayField.onFocus}
+                        keyboardType="number-pad"
+                        maxLength={10}
+                      />
+                    </View>
+                  </View>
+
+                  <View style={styles.inputContainer}>
+                    <Text style={styles.inputLabel}>성별</Text>
+                    <View style={styles.genderGroup}>
+                      <TouchableOpacity
+                        activeOpacity={0.8}
+                        style={[
+                          styles.genderButton,
+                          formData.gender === 'F' && styles.genderButtonActive,
+                        ]}
+                        onPress={() => handleGenderChange('F')}>
+                        <Text
+                          style={[
+                            styles.genderButtonText,
+                            formData.gender === 'F' &&
+                              styles.genderButtonTextActive,
+                          ]}>
+                          여성
+                        </Text>
+                      </TouchableOpacity>
+                      <TouchableOpacity
+                        activeOpacity={0.8}
+                        style={[
+                          styles.genderButton,
+                          formData.gender === 'M' && styles.genderButtonActive,
+                        ]}
+                        onPress={() => handleGenderChange('M')}>
+                        <Text
+                          style={[
+                            styles.genderButtonText,
+                            formData.gender === 'M' &&
+                              styles.genderButtonTextActive,
+                          ]}>
+                          남성
+                        </Text>
+                      </TouchableOpacity>
+                    </View>
+                  </View>
+                </>
+              )}
+
               <View
                 style={styles.inputContainer}
                 onLayout={nicknameField.onLayout}>
@@ -359,101 +508,113 @@ const UserRegisterProfile = () => {
                   </View>
                 )}
               </View>
-              <View
-                style={styles.inputContainer}
-                onLayout={passwordField.onLayout}>
-                <Text style={styles.inputLabel}>비밀번호</Text>
-                <View style={styles.inputBox}>
-                  <TextInput
-                    style={styles.textInput}
-                    placeholder="비밀번호를 입력해주세요"
-                    placeholderTextColor={COLORS.grayscale_400}
-                    value={formData.password}
-                    onChangeText={handlePasswordChange}
-                    onFocus={passwordField.onFocus}
-                    maxLength={20}
-                    secureTextEntry={!isPasswordVisible}
-                    autoCapitalize="none"
-                  />
-                  <TouchableOpacity
-                    activeOpacity={1}
-                    onPress={() => setIsPasswordVisible(prev => !prev)}>
-                    {isPasswordVisible ? (
-                      <HidePassword width={24} hide={24} />
-                    ) : (
-                      <ShowPassword width={24} hide={24} />
-                    )}
-                  </TouchableOpacity>
-                </View>
-                <View style={styles.validBox}>
-                  <Text
-                    style={[
-                      styles.validDefaultText,
-                      formValid.password.hasUpperLowercase
-                        ? styles.validText
-                        : '',
-                    ]}>
-                    영문 대소문자 포함
-                  </Text>
-                  <Text
-                    style={[
-                      styles.validDefaultText,
-                      formValid.password.hasNumber ? styles.validText : '',
-                    ]}>
-                    숫자 포함
-                  </Text>
-                  <Text
-                    style={[
-                      styles.validDefaultText,
-                      formValid.password.hasSpecialChar ? styles.validText : '',
-                    ]}>
-                    특수문자 포함
-                  </Text>
-                  <Text
-                    style={[
-                      styles.validDefaultText,
-                      formValid.password.isLengthValid ? styles.validText : '',
-                    ]}>
-                    8-20자 이내
-                  </Text>
-                </View>
-              </View>
-              <View
-                style={styles.inputContainer}
-                onLayout={passwordConfirmField.onLayout}>
-                <View style={styles.inputBox}>
-                  <TextInput
-                    style={styles.textInput}
-                    placeholder="다시 한 번 입력해주세요"
-                    placeholderTextColor={COLORS.grayscale_400}
-                    value={formData.passwordConfirm}
-                    onChangeText={handlePasswordConfirmChange}
-                    onFocus={passwordConfirmField.onFocus}
-                    maxLength={20}
-                    secureTextEntry={!isPasswordCheckVisible}
-                  />
-                  <TouchableOpacity
-                    activeOpacity={1}
-                    onPress={() => setIsPasswordCheckVisible(prev => !prev)}>
-                    {isPasswordCheckVisible ? (
-                      <HidePassword width={24} hide={24} />
-                    ) : (
-                      <ShowPassword width={24} hide={24} />
-                    )}
-                  </TouchableOpacity>
-                </View>
-                <View style={styles.validBox}>
-                  <Text
-                    style={[
-                      styles.validDefaultText,
-                      formValid.passwordConfirm.isMatched
-                        ? styles.validText
-                        : '',
-                    ]}>
-                    비밀번호 일치
-                  </Text>
-                </View>
-              </View>
+              {!isSocialSignUp && (
+                <>
+                  <View
+                    style={styles.inputContainer}
+                    onLayout={passwordField.onLayout}>
+                    <Text style={styles.inputLabel}>비밀번호</Text>
+                    <View style={styles.inputBox}>
+                      <TextInput
+                        style={styles.textInput}
+                        placeholder="비밀번호를 입력해주세요"
+                        placeholderTextColor={COLORS.grayscale_400}
+                        value={formData.password}
+                        onChangeText={handlePasswordChange}
+                        onFocus={passwordField.onFocus}
+                        maxLength={20}
+                        secureTextEntry={!isPasswordVisible}
+                        autoCapitalize="none"
+                      />
+                      <TouchableOpacity
+                        activeOpacity={1}
+                        onPress={() => setIsPasswordVisible(prev => !prev)}>
+                        {isPasswordVisible ? (
+                          <HidePassword width={24} hide={24} />
+                        ) : (
+                          <ShowPassword width={24} hide={24} />
+                        )}
+                      </TouchableOpacity>
+                    </View>
+                    <View style={styles.validBox}>
+                      <Text
+                        style={[
+                          styles.validDefaultText,
+                          formValid.password.hasUpperLowercase
+                            ? styles.validText
+                            : '',
+                        ]}>
+                        영문 대소문자 포함
+                      </Text>
+                      <Text
+                        style={[
+                          styles.validDefaultText,
+                          formValid.password.hasNumber
+                            ? styles.validText
+                            : '',
+                        ]}>
+                        숫자 포함
+                      </Text>
+                      <Text
+                        style={[
+                          styles.validDefaultText,
+                          formValid.password.hasSpecialChar
+                            ? styles.validText
+                            : '',
+                        ]}>
+                        특수문자 포함
+                      </Text>
+                      <Text
+                        style={[
+                          styles.validDefaultText,
+                          formValid.password.isLengthValid
+                            ? styles.validText
+                            : '',
+                        ]}>
+                        8-20자 이내
+                      </Text>
+                    </View>
+                  </View>
+                  <View
+                    style={styles.inputContainer}
+                    onLayout={passwordConfirmField.onLayout}>
+                    <View style={styles.inputBox}>
+                      <TextInput
+                        style={styles.textInput}
+                        placeholder="다시 한 번 입력해주세요"
+                        placeholderTextColor={COLORS.grayscale_400}
+                        value={formData.passwordConfirm}
+                        onChangeText={handlePasswordConfirmChange}
+                        onFocus={passwordConfirmField.onFocus}
+                        maxLength={20}
+                        secureTextEntry={!isPasswordCheckVisible}
+                      />
+                      <TouchableOpacity
+                        activeOpacity={1}
+                        onPress={() =>
+                          setIsPasswordCheckVisible(prev => !prev)
+                        }>
+                        {isPasswordCheckVisible ? (
+                          <HidePassword width={24} hide={24} />
+                        ) : (
+                          <ShowPassword width={24} hide={24} />
+                        )}
+                      </TouchableOpacity>
+                    </View>
+                    <View style={styles.validBox}>
+                      <Text
+                        style={[
+                          styles.validDefaultText,
+                          formValid.passwordConfirm.isMatched
+                            ? styles.validText
+                            : '',
+                        ]}>
+                        비밀번호 일치
+                      </Text>
+                    </View>
+                  </View>
+                </>
+              )}
             </View>
           </View>
           <View>

--- a/packages/app/src/utils/api/authApi.js
+++ b/packages/app/src/utils/api/authApi.js
@@ -23,30 +23,33 @@ const authApi = {
       withAuth: false,
     }),
 
-  // NICE 본인인증 init (encData 등 받기)
-  niceInit: () =>
-    api.post('/auth/nice/init', null, {
-      withAuth: false,
-    }),
+  /**
+   * NICE 기반 USER 가입/본인인증 보조 경로
+   *
+   * 백엔드에서 NICE API가 제거되며 아래 경로는 410 Gone으로 전환됨.
+   * 새 가입 플로우는 SMS purpose 기반 인증과 /auth/user/signup,
+   * /auth/user/signup/social/complete 계약으로 교체해야 함.
+   */
+  // niceInit: () =>
+  //   api.post('/auth/nice/init', null, {
+  //     withAuth: false,
+  //   }),
 
-  // 본인인증 후 계정 상태 확인 (NEW_USER / ALREADY_LOCAL / SOCIAL_INTEGRATION)
-  checkSignUpStatus: niceAuthToken =>
-    api.post('/auth/user/check-status', null, {
-      params: {niceAuthToken},
-      withAuth: false,
-    }),
+  // checkSignUpStatus: niceAuthToken =>
+  //   api.post('/auth/user/check-status', null, {
+  //     params: {niceAuthToken},
+  //     withAuth: false,
+  //   }),
 
-  // 최종 회원가입/연동 완료
-  completeUserSignUp: body =>
-    api.post('/auth/user/signup/complete', body, {
-      withAuth: false,
-    }),
+  // completeUserSignUp: body =>
+  //   api.post('/auth/user/signup/complete', body, {
+  //     withAuth: false,
+  //   }),
 
-  // 결측 CI 수집 완료 후 CI 등록
-  verifyCi: (niceAuthToken) =>
-    api.post('/auth/user/verify-ci', {niceAuthToken}, {
-      withAuth: true, // 로그인 상태에서 호출, 토큰 포함
-    }),
+  // verifyCi: niceAuthToken =>
+  //   api.post('/auth/user/verify-ci', {niceAuthToken}, {
+  //     withAuth: true,
+  //   }),
 
   // 소셜 회원가입 완료
   completeSocialSignUp: body =>
@@ -54,15 +57,16 @@ const authApi = {
       withAuth: false,
     }),
 
-  //휴대폰 인증
-  sendSms: (phoneNum, userRole) =>
+  // 휴대폰 인증
+  // purpose: SIGN_UP | FIND_ACCOUNT | PHONE_CHANGE
+  sendSms: (phoneNum, userRole, purpose = 'SIGN_UP') =>
     api.post('/auth/sms/send', null, {
-      params: {phoneNum, userRole},
+      params: {phoneNum, userRole, purpose},
       withAuth: false,
     }),
-  verifySms: (phoneNum, code) =>
+  verifySms: (phoneNum, code, userRole = 'USER', purpose = 'SIGN_UP') =>
     api.post('/auth/sms/verify', null, {
-      params: {phoneNum, code},
+      params: {phoneNum, code, userRole, purpose},
       withAuth: false,
     }),
   //사장님 회원가입

--- a/packages/app/src/utils/auth/login.js
+++ b/packages/app/src/utils/auth/login.js
@@ -6,11 +6,87 @@ import useUserStore from '@stores/userStore';
 import userMyApi from '@utils/api/userMyApi';
 import { log, mask } from '@utils/logger';
 import { reset } from '@utils/navigationService';
-import { login as kakaoLogin } from '@react-native-seoul/kakao-login';
+import {
+  getProfile as kakaoGetProfile,
+  login as kakaoLogin,
+} from '@react-native-seoul/kakao-login';
 import { syncFcmToken, getDeviceId } from '@utils/fcmService';
 import notificationApi from '@utils/api/notificationApi';
 
 const REFRESH_KEY = 'refresh-token';
+
+const cleanKakaoValue = value => {
+  if (value == null) {
+    return '';
+  }
+
+  const text = String(value);
+  return text === 'null' || text === 'undefined' ? '' : text;
+};
+
+const normalizeGender = value => {
+  const gender = cleanKakaoValue(value).toLowerCase();
+
+  if (gender === 'female' || gender === 'f') {
+    return 'F';
+  }
+  if (gender === 'male' || gender === 'm') {
+    return 'M';
+  }
+
+  return '';
+};
+
+const normalizeBirthday = ({birthday, birthyear}) => {
+  const rawBirthday = cleanKakaoValue(birthday);
+  const rawBirthyear = cleanKakaoValue(birthyear);
+
+  if (/^\d{4}-\d{2}-\d{2}$/.test(rawBirthday)) {
+    return rawBirthday;
+  }
+
+  if (/^\d{4}$/.test(rawBirthyear) && /^\d{4}$/.test(rawBirthday)) {
+    return `${rawBirthyear}-${rawBirthday.slice(0, 2)}-${rawBirthday.slice(2)}`;
+  }
+
+  return '';
+};
+
+const normalizeSocialProfile = data => {
+  const profile = data?.profile || data?.socialProfile || {};
+  return {
+    email: cleanKakaoValue(profile.email || data?.email),
+    nickname: cleanKakaoValue(profile.nickname || data?.nickname),
+    name: cleanKakaoValue(profile.name || data?.name),
+    birthday: normalizeBirthday({
+      birthday: profile.birthday || data?.birthday,
+      birthyear: profile.birthyear || data?.birthyear,
+    }),
+    gender: normalizeGender(profile.gender || data?.gender),
+  };
+};
+
+const mergeSocialProfiles = (...profiles) =>
+  profiles.reduce(
+    (merged, profile = {}) => ({
+      email: merged.email || profile.email || '',
+      nickname: merged.nickname || profile.nickname || '',
+      name: merged.name || profile.name || '',
+      birthday: merged.birthday || profile.birthday || '',
+      gender: merged.gender || profile.gender || '',
+    }),
+    {},
+  );
+
+const getKakaoProfileFallback = async () => {
+  try {
+    const profile = await kakaoGetProfile();
+    return normalizeSocialProfile(profile);
+  } catch (error) {
+    log.warn('카카오 프로필 조회 실패:', error?.message);
+    return {};
+  }
+};
 
 const clearAuthSession = async ({ silent = false } = {}) => {
   try {
@@ -35,8 +111,23 @@ export const tryKakaoLoginNative = async (userRole) => {
 
     // 2. 획득한 accessToken을 백엔드로 전달
     const res = await authApi.loginKakao(kakaoToken.accessToken);
+    const data = res.data || {};
 
-    // 3. 백엔드에서 응답받은 우리 서비스의 토큰을 저장
+    if (data.isNewUser) {
+      const backendProfile = normalizeSocialProfile(data);
+      const sdkProfile = await getKakaoProfileFallback();
+
+      return {
+        success: true,
+        isNewUser: true,
+        provider: 'KAKAO',
+        socialSignupToken: data.socialSignupToken,
+        socialProfile: mergeSocialProfiles(backendProfile, sdkProfile),
+        message: data.message,
+      };
+    }
+
+    // 3. 기존 유저일 때만 백엔드에서 응답받은 우리 서비스의 토큰을 저장
     await storeLoginInfo(res, userRole);
 
     // 4. FCM 토큰 동기화 (Authorization 헤더가 설정된 상태로 등록)
@@ -44,8 +135,8 @@ export const tryKakaoLoginNative = async (userRole) => {
 
     return {
       success: true,
-      isNewUser: res.data.isNewUser,
-      externalId: res.data.externalId
+      isNewUser: false,
+      provider: 'KAKAO',
     };
   } catch (err) {
     log.warn('❌ tryKakaoLoginNative failed:', err?.message);
@@ -53,7 +144,7 @@ export const tryKakaoLoginNative = async (userRole) => {
 
     return {
       success: false,
-      message: err?.message
+      message: err?.message,
     };
   }
 };
@@ -63,14 +154,18 @@ export const tryAutoLogin = async () => {
   try {
     const storedRefresh = await EncryptedStorage.getItem(REFRESH_KEY);
     log.info('🔐 has refreshToken?', !!storedRefresh);
-    if (!storedRefresh) return false;
+    if (!storedRefresh) {
+      return false;
+    }
 
     const ok = await tryRefresh({ silent: true });
     log.info('🚪 tryAutoLogin: refresh result =', ok);
     if (ok) {
       const { userRole } = useUserStore.getState();
       log.info('👤 tryAutoLogin: userRole =', userRole);
-      if (userRole) await updateProfile(userRole);
+      if (userRole) {
+        await updateProfile(userRole);
+      }
     }
     return ok;
   } catch (err) {
@@ -83,7 +178,7 @@ export const storeLoginTokens = async ({
   accessToken,
   refreshToken,
   userRole,
-  needVerification
+  needVerification,
 }) => {
   log.info(
     '✅ login success: accessToken=',
@@ -93,16 +188,20 @@ export const storeLoginTokens = async ({
     'role=',
     userRole,
     'needVerification=',
-    needVerification
+    needVerification,
   );
 
   const { setTokens, setUserRole, setIsVerified } = useUserStore.getState();
-  if (accessToken) setTokens({ accessToken });
-  if (userRole) setUserRole(userRole);
+  if (accessToken) {
+    setTokens({ accessToken });
+  }
+  if (userRole) {
+    setUserRole(userRole);
+  }
 
-  // needVerification이 "true"면 본인 인증이 안 된 상태이므로 false 저장
+  // needVerification이 'true'면 본인 인증이 안 된 상태이므로 false 저장
   if (setIsVerified) {
-    setIsVerified(needVerification !== "true");
+    setIsVerified(needVerification !== 'true');
   }
 
   if (refreshToken) {
@@ -156,8 +255,20 @@ export const tryKakaoLogin = async (accessCode, userRole) => {
   log.info('🟨 tryKakaoLogin: role=', userRole);
   try {
     const res = await authApi.loginKakao(accessCode);
+    const data = res.data || {};
+    if (data.isNewUser) {
+      const backendProfile = normalizeSocialProfile(data);
+
+      return {
+        success: true,
+        isNewUser: true,
+        provider: 'KAKAO',
+        socialSignupToken: data.socialSignupToken,
+        socialProfile: backendProfile,
+      };
+    }
     await storeLoginInfo(res, userRole);
-    return { success: true, isNewUser: res.data.isNewUser };
+    return { success: true, isNewUser: false, provider: 'KAKAO' };
   } catch (err) {
     log.warn('❌ tryKakaoLogin failed:', err?.message);
     useUserStore.getState().clearUser();
@@ -261,7 +372,9 @@ const updateProfile = async role => {
 };
 
 export function calculateAge(birthDateString) {
-  if (!birthDateString) return '00';
+  if (!birthDateString) {
+    return '00';
+  }
   const today = new Date();
   const birthDate = new Date(birthDateString);
   let age = today.getFullYear() - birthDate.getFullYear();


### PR DESCRIPTION
## 작업 개요

백엔드 로그인/회원가입 계약 변경에 맞춰 사용자 회원가입 흐름을 수정했습니다.

기존 NICE 기반 본인인증/가입 보조 경로를 비활성화하고, SMS 인증 기반 회원가입 및 `provider + socialSignupToken` 기반 소셜 회원가입 흐름으로 정리했습니다.

이번 작업 범위는 카카오 소셜 로그인/회원가입 중심이며, 네이버/구글 소셜 로그인은 이번 PR에서 처리하지 않았습니다.

## 주요 변경 사항

### 1. NICE 기반 가입 보조 경로 비활성화

백엔드에서 NICE 관련 API가 제거됨에 따라 기존 NICE 기반 가입 보조 API 호출을 주석 처리했습니다.

- `niceInit`
- `checkSignUpStatus`
- `completeUserSignUp`
- `verifyCi`

기존 NICE 흐름 대신 일반 사용자 가입은 아래 흐름을 사용합니다.

```txt
약관 동의
→ 이메일 인증
→ SMS 전화번호 인증
→ 프로필 입력
→ /auth/user/signup
```

### 2. SMS 인증 purpose 반영

백엔드 SMS 인증 API가 `purpose` 값을 요구하도록 변경되어 프론트 호출부에 반영했습니다.

- 회원가입: `SIGN_UP`
- 계정 찾기: `FIND_ACCOUNT`
- 기존 전화번호 소셜 연동 인증: `FIND_ACCOUNT`

변경된 API 호출 형태:

```js
sendSms(phoneNum, userRole, purpose)
verifySms(phoneNum, code, userRole, purpose)
```

### 3. 카카오 소셜 로그인 신규 가입 흐름 수정

백엔드 소셜 로그인 응답이 `externalId` 기반에서 `socialSignupToken` 기반으로 변경되어 프론트 흐름을 수정했습니다.

신규 카카오 유저 흐름:

```txt
카카오 로그인
→ /auth/user/social-login
→ isNewUser=true, socialSignupToken 수신
→ 약관 동의
→ SMS 전화번호 인증
→ /auth/user/signup/social/complete
```

최종 소셜 회원가입 완료 요청 body:

```js
{
  provider,
  socialSignupToken,
  userRole,
  phoneNum,
  name,
  birthday,
  gender,
  nickname,
  agreements,
}
```

### 4. 카카오 SDK 프로필 조회 반영

카카오 SDK의 `getProfile()`을 사용해 카카오 프로필 정보를 조회하도록 추가했습니다.

백엔드 응답 프로필과 SDK 프로필을 병합해서 사용하며, 아래 값들을 소셜 가입에 활용합니다.

- 이메일
- 이름
- 생년월일
- 성별
- 닉네임

카카오에서 필수 프로필 값이 모두 내려오면 별도 입력 화면 없이 전화번호 인증 후 바로 소셜 회원가입 완료를 시도합니다.

필수값이 부족하거나 닉네임 중복 등으로 가입 완료가 실패하면 기존 프로필 입력 화면으로 이동해 사용자가 직접 수정할 수 있도록 처리했습니다.

### 5. 일반 로컬 회원가입 흐름 유지 확인

`isSocial === false` 일반 회원가입 경로도 확인했습니다.

일반 회원가입 흐름에서는 `provider`, `socialSignupToken` 없이 진행되며, 최종 `/auth/user/signup` body는 아래 값만 전달합니다.

```js
{
  email,
  password,
  passwordConfirm,
  nickname,
  userRole,
  phoneNum,
  agreements,
}
```

약관 동의 정보는 아래 경로로 유지됩니다.

```txt
RegisterAgree
→ EmailCertificate
→ PhoneCertificate
→ UserRegisterProfile
```

## 확인한 사항

- 카카오 신규 회원가입 시 `provider`, `socialSignupToken`, `socialProfile` 전달 확인
- 소셜 회원가입 완료 body 확인
- 일반 회원가입 body 확인
- SMS 인증 purpose 전달 확인
- NICE API 실제 호출 제거 확인
- 네이버/구글 소셜 로그인은 이번 작업 범위에서 제외
- `eslint` 통과
- `git diff --check` 통과

## 참고 및 후속 정리 필요 사항

`UserPhone.js`는 현재 실제 사용처는 없지만, 기존 NICE 본인인증 컴포넌트가 파일로 남아 있습니다.

현재 사용자 플로우에서는 접근되지 않지만, 추후 NICE 제거 작업을 완전히 마무리할 때 컴포넌트/라우팅 정리를 함께 진행하면 좋습니다.

또한 기존 이메일 로그인에서 `needVerification === true`일 때 `PhoneCertificate`로 이동하는 오래된 CI 보완 경로가 남아 있습니다. 백엔드에서 해당 값을 더 이상 내려주지 않는지 확인하거나, 후속 PR에서 정리하는 것이 좋습니다.