### PR TITLE
fix: 소셜 회원가입 닉네임 자동 생성 정책 반영

### DIFF
--- a/packages/app/src/screens/(Common)/Register/PhoneCertificate/index.js
+++ b/packages/app/src/screens/(Common)/Register/PhoneCertificate/index.js
@@ -75,12 +75,10 @@ const PhoneCertificate = ({route}) => {
   const socialProfileName = socialProfile.name || '';
   const socialProfileBirthday = socialProfile.birthday || '';
   const socialProfileGender = socialProfile.gender || '';
-  const socialProfileNickname = socialProfile.nickname || '';
   const hasCompleteSocialProfile =
     !!socialProfileName &&
     /^\d{4}-\d{2}-\d{2}$/.test(socialProfileBirthday) &&
-    (socialProfileGender === 'M' || socialProfileGender === 'F') &&
-    !!socialProfileNickname;
+    (socialProfileGender === 'M' || socialProfileGender === 'F');
 
   const moveToSocialProfileFallback = useCallback(() => {
     navigation.navigate('UserRegisterProfile', {
@@ -95,7 +93,6 @@ const PhoneCertificate = ({route}) => {
         name: socialProfileName,
         birthday: socialProfileBirthday,
         gender: socialProfileGender,
-        nickname: socialProfileNickname,
         password: '',
         passwordConfirm: '',
       },
@@ -111,7 +108,6 @@ const PhoneCertificate = ({route}) => {
     socialProfileEmail,
     socialProfileGender,
     socialProfileName,
-    socialProfileNickname,
     socialSignupToken,
     userRole,
   ]);
@@ -122,12 +118,9 @@ const PhoneCertificate = ({route}) => {
     const message = data?.message || error?.message || '';
 
     return (
-      errorCode.includes('NICKNAME') ||
       errorCode.includes('PROFILE') ||
       errorCode.includes('REQUIRED') ||
-      message.includes('닉네임') ||
-      message.includes('필수') ||
-      message.includes('중복')
+      message.includes('필수')
     );
   };
 
@@ -143,7 +136,6 @@ const PhoneCertificate = ({route}) => {
         name: socialProfileName,
         birthday: socialProfileBirthday,
         gender: socialProfileGender,
-        nickname: socialProfileNickname,
         agreements,
       });
 
@@ -199,7 +191,6 @@ const PhoneCertificate = ({route}) => {
     socialProfileBirthday,
     socialProfileGender,
     socialProfileName,
-    socialProfileNickname,
     socialSignupToken,
     userRole,
   ]);

--- a/packages/app/src/screens/(User)/UserRegister/UserRegisterProfile/index.js
+++ b/packages/app/src/screens/(User)/UserRegister/UserRegisterProfile/index.js
@@ -193,7 +193,7 @@ const UserRegisterProfile = () => {
       );
       const genderValid = formData.gender === 'M' || formData.gender === 'F';
 
-      return nicknameValid && nameValid && birthdayValid && genderValid;
+      return nameValid && birthdayValid && genderValid;
     }
 
     return nicknameValid && passwordValid && confirmValid;
@@ -210,7 +210,6 @@ const UserRegisterProfile = () => {
           name: formData.name,
           birthday: formData.birthday,
           gender: formData.gender,
-          nickname: formData.nickname,
           agreements: formData.agreements,
         };
 
@@ -429,85 +428,87 @@ const UserRegisterProfile = () => {
                 </>
               )}
 
-              <View
-                style={styles.inputContainer}
-                onLayout={nicknameField.onLayout}>
-                <Text style={styles.inputLabel}>닉네임</Text>
-                <View style={[styles.inputBox, styles.inputRelative]}>
-                  <TextInput
-                    style={styles.textInput}
-                    placeholder="닉네임을 입력해주세요"
-                    placeholderTextColor={COLORS.grayscale_400}
-                    value={formData.nickname}
-                    onChangeText={handleNicknameChange}
-                    onFocus={nicknameField.onFocus}
-                    maxLength={10}
-                  />
-                  <TouchableOpacity
-                    activeOpacity={1}
-                    disabled={
-                      !formValid.nickname?.hasNoSpecialChars ||
-                      !formValid.nickname?.isLengthValid
-                    }
-                    style={[
-                      styles.inputButtonAbsolute,
-                      {
-                        backgroundColor:
-                          formValid.nickname?.hasNoSpecialChars &&
+              {!isSocialSignUp && (
+                <View
+                  style={styles.inputContainer}
+                  onLayout={nicknameField.onLayout}>
+                  <Text style={styles.inputLabel}>닉네임</Text>
+                  <View style={[styles.inputBox, styles.inputRelative]}>
+                    <TextInput
+                      style={styles.textInput}
+                      placeholder="닉네임을 입력해주세요"
+                      placeholderTextColor={COLORS.grayscale_400}
+                      value={formData.nickname}
+                      onChangeText={handleNicknameChange}
+                      onFocus={nicknameField.onFocus}
+                      maxLength={10}
+                    />
+                    <TouchableOpacity
+                      activeOpacity={1}
+                      disabled={
+                        !formValid.nickname?.hasNoSpecialChars ||
+                        !formValid.nickname?.isLengthValid
+                      }
+                      style={[
+                        styles.inputButtonAbsolute,
+                        {
+                          backgroundColor:
+                            formValid.nickname?.hasNoSpecialChars &&
+                            formValid.nickname?.isLengthValid
+                              ? COLORS.primary_orange
+                              : COLORS.grayscale_200,
+                        },
+                      ]}
+                      onPress={checkNicknameDuplicate}>
+                      <Text
+                        style={{
+                          ...FONTS.fs_14_medium,
+                          color:
+                            formValid.nickname?.hasNoSpecialChars &&
+                            formValid.nickname?.isLengthValid
+                              ? COLORS.grayscale_0
+                              : COLORS.grayscale_400,
+                        }}>
+                        중복확인
+                      </Text>
+                    </TouchableOpacity>
+                  </View>
+                  {isNicknameChecked ? (
+                    <View style={styles.validBox}>
+                      <Text
+                        style={[
+                          styles.validDefaultText,
+                          !isNicknameDuplicated
+                            ? styles.validText
+                            : styles.invalidText,
+                        ]}>
+                        {nicknameCheckMessage}
+                      </Text>
+                    </View>
+                  ) : (
+                    <View style={styles.validBox}>
+                      <Text
+                        style={[
+                          styles.validDefaultText,
+                          formValid.nickname?.hasNoSpecialChars
+                            ? styles.validText
+                            : '',
+                        ]}>
+                        특수문자 제외
+                      </Text>
+                      <Text
+                        style={[
+                          styles.validDefaultText,
                           formValid.nickname?.isLengthValid
-                            ? COLORS.primary_orange
-                            : COLORS.grayscale_200,
-                      },
-                    ]}
-                    onPress={checkNicknameDuplicate}>
-                    <Text
-                      style={{
-                        ...FONTS.fs_14_medium,
-                        color:
-                          formValid.nickname?.hasNoSpecialChars &&
-                          formValid.nickname?.isLengthValid
-                            ? COLORS.grayscale_0
-                            : COLORS.grayscale_400,
-                      }}>
-                      중복확인
-                    </Text>
-                  </TouchableOpacity>
+                            ? styles.validText
+                            : '',
+                        ]}>
+                        2-10자 내외
+                      </Text>
+                    </View>
+                  )}
                 </View>
-                {isNicknameChecked ? (
-                  <View style={styles.validBox}>
-                    <Text
-                      style={[
-                        styles.validDefaultText,
-                        !isNicknameDuplicated
-                          ? styles.validText
-                          : styles.invalidText,
-                      ]}>
-                      {nicknameCheckMessage}
-                    </Text>
-                  </View>
-                ) : (
-                  <View style={styles.validBox}>
-                    <Text
-                      style={[
-                        styles.validDefaultText,
-                        formValid.nickname?.hasNoSpecialChars
-                          ? styles.validText
-                          : '',
-                      ]}>
-                      특수문자 제외
-                    </Text>
-                    <Text
-                      style={[
-                        styles.validDefaultText,
-                        formValid.nickname?.isLengthValid
-                          ? styles.validText
-                          : '',
-                      ]}>
-                      2-10자 내외
-                    </Text>
-                  </View>
-                )}
-              </View>
+              )}
               {!isSocialSignUp && (
                 <>
                   <View


### PR DESCRIPTION
## 작업 내용

- 소셜 회원가입 완료 요청에서 `nickname` 전달을 제거했습니다.
- 카카오 회원가입 시 닉네임은 백엔드에서 자동 생성하도록 프론트 흐름을 정리했습니다.
- 소셜 회원가입 보완 입력 화면에서 닉네임 입력/중복확인 UI가 노출되지 않도록 수정했습니다.
- 소셜 회원가입 유효성 검사를 이름, 생년월일, 성별 기준으로 변경했습니다.
- 일반 회원가입의 닉네임 입력 및 중복확인 흐름은 기존대로 유지했습니다.

## 변경 이유

백엔드에서 소셜 회원가입 사용자의 닉네임을 자동 생성하는 정책으로 변경되었습니다.

기존에는 카카오 프로필의 닉네임을 프론트에서 전달하거나, 닉네임이 없거나 중복될 경우 사용자가 직접 입력해야 했습니다.  
이제는 소셜 회원가입 시 프론트가 닉네임을 전달하지 않고, 백엔드가 기본 닉네임을 생성하도록 변경했습니다.

## 확인 사항

- 카카오 프로필에 이름, 생년월일, 성별이 모두 있는 경우 자동 회원가입 요청이 정상적으로 진행됩니다.
- 카카오 프로필에 성별 등 필수 정보가 없는 경우 보완 입력 화면으로 이동합니다.
- 보완 입력 화면에서도 소셜 회원가입 API에 `nickname`은 포함되지 않습니다.
- 일반 회원가입에서는 닉네임 입력 및 중복확인이 기존처럼 동작합니다.