### PR TITLE
스탭 지원 및 이력서 작성 흐름 개선

### DIFF
--- a/packages/app/src/components/Employ/ApplicantDetail/ApplicantExperienceSection.js
+++ b/packages/app/src/components/Employ/ApplicantDetail/ApplicantExperienceSection.js
@@ -1,4 +1,4 @@
-import React, {useState} from 'react';
+import React from 'react';
 import {View, Text, StyleSheet, TouchableOpacity} from 'react-native';
 import {COLORS} from '@constants/colors';
 import {FONTS} from '@constants/fonts';
@@ -8,29 +8,22 @@ import EditIcon from '@assets/images/edit_gray.svg';
 import TrashcanIcon from '@assets/images/delete_gray.svg';
 import {parseSlashDateToYearMonthDot} from '@utils/formatDate';
 import ButtonWhite from '@components/ButtonWhite';
-import EmployExperienceModal from '@components/modals/Employ/EmployExperienceModal';
 
 const ApplicantExperienceSection = ({
-  experiences,
+  experiences = [],
   isEditable = false,
   setExperience = null,
+  onAddExperience = () => {},
+  onEditExperience = () => {},
 }) => {
-  const [modalVisible, setModalVisible] = useState(false);
-  const [editingIndex, setEditingIndex] = useState(null);
-  const [editingData, setEditingData] = useState(null);
-
   // 추가 버튼 클릭
   const handleAdd = () => {
-    setEditingIndex(null);
-    setEditingData(null);
-    setModalVisible(true);
+    onAddExperience();
   };
 
   // 수정 버튼 클릭
   const handleEdit = (exp, index) => {
-    setEditingIndex(index);
-    setEditingData(exp);
-    setModalVisible(true);
+    onEditExperience(exp, index);
   };
 
   // 삭제 버튼 클릭
@@ -86,24 +79,6 @@ const ApplicantExperienceSection = ({
         <></>
       )}
 
-      <EmployExperienceModal
-        visible={modalVisible}
-        initialData={editingData}
-        onClose={() => setModalVisible(false)}
-        addExperience={data => {
-          let updated = [];
-          if (editingIndex !== null) {
-            // 수정
-            updated = [...experiences];
-            updated[editingIndex] = data;
-          } else {
-            // 추가
-            updated = [...experiences, data];
-          }
-          setExperience(updated);
-          setModalVisible(false);
-        }}
-      />
     </View>
   );
 };

--- a/packages/app/src/components/Employ/ApplicantDetail/ApplicantSelfIntroduction.js
+++ b/packages/app/src/components/Employ/ApplicantDetail/ApplicantSelfIntroduction.js
@@ -1,6 +1,5 @@
-import React, {useState} from 'react';
+import React from 'react';
 import {View, Text, TouchableOpacity, StyleSheet} from 'react-native';
-import EmploySelfIntroModal from '@components/modals/Employ/EmploySelfIntroModal';
 import {COLORS} from '@constants/colors';
 import {FONTS} from '@constants/fonts';
 import EditIcon from '@assets/images/edit_gray.svg';
@@ -8,15 +7,14 @@ import EditIcon from '@assets/images/edit_gray.svg';
 const ApplicantSelfIntroduction = ({
   text = '',
   isEditable = false,
-  setSelfIntro = null,
+  onEditSelfIntro = () => {},
 }) => {
-  const [modalVisible, setModalVisible] = useState(false);
   return (
     <View style={styles.sectionBox}>
       <View style={styles.titleBox}>
         <Text style={styles.titleText}>자기소개</Text>
         {isEditable ? (
-          <TouchableOpacity onPress={() => setModalVisible(true)}>
+          <TouchableOpacity onPress={onEditSelfIntro}>
             <EditIcon width={24} />
           </TouchableOpacity>
         ) : (
@@ -27,19 +25,16 @@ const ApplicantSelfIntroduction = ({
         <Text style={{color: COLORS.primary_orange}}>
           {text?.length?.toLocaleString()}
         </Text>
-        /50,000
+        /1,000
       </Text>
 
-      <View style={styles.introductionCard}>
+      <TouchableOpacity
+        activeOpacity={isEditable ? 0.8 : 1}
+        disabled={!isEditable}
+        style={styles.introductionCard}
+        onPress={onEditSelfIntro}>
         <Text style={styles.introductionText}>{text}</Text>
-      </View>
-
-      <EmploySelfIntroModal
-        visible={modalVisible}
-        onClose={() => setModalVisible(false)}
-        editSelfIntro={setSelfIntro}
-        initialData={text}
-      />
+      </TouchableOpacity>
     </View>
   );
 };

--- a/packages/app/src/components/Employ/ApplicantDetail/ApplicantTag.js
+++ b/packages/app/src/components/Employ/ApplicantDetail/ApplicantTag.js
@@ -1,12 +1,10 @@
-import React, {useState} from 'react';
+import React from 'react';
 import {View, Text, StyleSheet, TouchableOpacity} from 'react-native';
 import {COLORS} from '@constants/colors';
 import {FONTS} from '@constants/fonts';
 import EditIcon from '@assets/images/edit_gray.svg';
-import EmployTagModal from '@components/modals/Employ/EmployTagModal';
 
-const ApplicantTag = ({tags, isEditable = false, setTags = null}) => {
-  const [modalVisible, setModalVisible] = useState(false);
+const ApplicantTag = ({tags, isEditable = false, onEditTags = () => {}}) => {
   return (
     <View>
       <View style={styles.sectionBox}>
@@ -20,7 +18,7 @@ const ApplicantTag = ({tags, isEditable = false, setTags = null}) => {
           {isEditable ? (
             <TouchableOpacity
               onPress={() => {
-                setModalVisible(true);
+                onEditTags();
               }}>
               <EditIcon width={24} />
             </TouchableOpacity>
@@ -36,12 +34,6 @@ const ApplicantTag = ({tags, isEditable = false, setTags = null}) => {
           ))}
         </View>
       </View>
-      <EmployTagModal
-        visible={modalVisible}
-        onClose={() => setModalVisible(false)}
-        addTags={setTags}
-        initialData={tags}
-      />
     </View>
   );
 };

--- a/packages/app/src/components/modals/Employ/EmployExperienceModal.js
+++ b/packages/app/src/components/modals/Employ/EmployExperienceModal.js
@@ -73,10 +73,6 @@ export default function EmployExperienceModal({
     setExperience(prev => ({ ...prev, [dateFieldTarget]: formatted }));
     setIsDatePickerVisible(false);
   };
-  if (Platform.OS === 'android' && !visible) {
-    return null;
-  }
-
   const content = (
     <KeyboardAvoidingView style={{ flex: 1 }} enabled>
       <TouchableWithoutFeedback onPress={Keyboard.dismiss} accessible={false}>
@@ -197,12 +193,13 @@ export default function EmployExperienceModal({
     </KeyboardAvoidingView>
   );
 
-  if (Platform.OS === 'android') {
-    return content;
-  }
-
   return (
-    <Modal visible={visible} animationType="slide" transparent onRequestClose={onClose}>
+    <Modal
+      visible={visible}
+      animationType="slide"
+      transparent
+      onRequestClose={onClose}
+      useNativeModalOnAndroid>
       {content}
     </Modal>
   );
@@ -219,16 +216,11 @@ const styles = StyleSheet.create({
     elevation: 9999,
   },
   container: {
-    flex: 1,
+    height: height * 0.9,
     backgroundColor: COLORS.grayscale_0,
     borderTopLeftRadius: 24,
     borderTopRightRadius: 24,
     paddingHorizontal: 20,
-    ...Platform.select({
-      ios: {
-        maxHeight: '90%',
-      },
-    }),
   },
   header: {
     flexDirection: 'row',

--- a/packages/app/src/components/modals/Employ/EmploySelfIntroModal.js
+++ b/packages/app/src/components/modals/Employ/EmploySelfIntroModal.js
@@ -1,5 +1,6 @@
 import React, {useEffect, useState} from 'react';
 import {
+  Dimensions,
   Keyboard,
   KeyboardAvoidingView,
   ScrollView,
@@ -9,7 +10,6 @@ import {
   TouchableOpacity,
   TouchableWithoutFeedback,
   View,
-  Platform,
 } from 'react-native';
 import Modal from '@components/modals/AdaptiveModal';
 import {FONTS} from '@constants/fonts';
@@ -17,6 +17,9 @@ import {COLORS} from '@constants/colors';
 import ButtonScarlet from '@components/ButtonScarlet';
 
 import XBtn from '@assets/images/x_gray.svg';
+
+const SELF_INTRO_MAX_LENGTH = 1000;
+const {height} = Dimensions.get('window');
 
 export default function EmploySelfIntroModal({
   visible,
@@ -31,7 +34,12 @@ export default function EmploySelfIntroModal({
   }, [initialData]);
 
   return (
-    <Modal visible={visible} animationType="slide" transparent>
+    <Modal
+      visible={visible}
+      animationType="slide"
+      transparent
+      onRequestClose={onClose}
+      useNativeModalOnAndroid>
       <KeyboardAvoidingView style={{flex: 1}} enabled>
         <TouchableWithoutFeedback onPress={Keyboard.dismiss} accessible={false}>
           <View style={styles.overlay}>
@@ -62,7 +70,7 @@ export default function EmploySelfIntroModal({
                     <Text style={{color: COLORS.primary_orange}}>
                       {selfIntro?.length?.toLocaleString()}
                     </Text>
-                    /50,000
+                    /1,000
                   </Text>
                   <View style={styles.inputBox}>
                     <TextInput
@@ -71,7 +79,7 @@ export default function EmploySelfIntroModal({
                       placeholderTextColor={COLORS.grayscale_400}
                       value={selfIntro}
                       onChangeText={setSelfIntro}
-                      maxLength={50000}
+                      maxLength={SELF_INTRO_MAX_LENGTH}
                       multiline
                       textAlignVertical="top"
                     />
@@ -109,16 +117,11 @@ const styles = StyleSheet.create({
     justifyContent: 'flex-end',
   },
   container: {
-    flex: 1, // height → flex: 1 로 수정
+    height: height * 0.9,
     backgroundColor: COLORS.grayscale_0,
     borderTopLeftRadius: 24,
     borderTopRightRadius: 24,
     paddingHorizontal: 20,
-    ...Platform.select({
-      ios: {
-        maxHeight: '90%',
-      },
-    }),
   },
   textInput: {
     flex: 1,

--- a/packages/app/src/components/modals/Employ/EmployTagModal.js
+++ b/packages/app/src/components/modals/Employ/EmployTagModal.js
@@ -44,7 +44,12 @@ export default function EmployTagModal({
     }
   };
   return (
-    <Modal visible={visible} animationType="slide" transparent>
+    <Modal
+      visible={visible}
+      animationType="slide"
+      transparent
+      onRequestClose={onClose}
+      useNativeModalOnAndroid>
       <View style={styles.overlay}>
         <View style={styles.container}>
           {/* 헤더 */}

--- a/packages/app/src/screens/(Common)/BottomTabs/Community/index.js
+++ b/packages/app/src/screens/(Common)/BottomTabs/Community/index.js
@@ -140,6 +140,10 @@ const Community = () => {
     () => getInitialCategoryKey(categoryTabs, route.params),
     [categoryTabs, route.params],
   );
+  const requestedCategory = useMemo(
+    () => normalizeCategoryParam(getRequestedCategoryParam(route.params)),
+    [route.params],
+  );
 
   const {
     pagerRef,
@@ -192,6 +196,31 @@ const Community = () => {
     didSyncInitialTabRef.current = true;
     setKey(initialCategoryKey, {animated: false, syncScroll: true});
   }, [initialCategoryKey, pageWidth, setKey]);
+
+  useEffect(() => {
+    if (pageWidth <= 0) {
+      return;
+    }
+
+    if (requestedCategory === 'ALL') {
+      setKey(getCategoryKey(allCategory), {
+        animated: false,
+        syncScroll: true,
+      });
+      return;
+    }
+
+    if (requestedCategory === 'STAFF' || requestedCategory === 'RECRUIT') {
+      const staffCategory = categoryTabs.find(isStaffCategory);
+
+      if (staffCategory) {
+        setKey(getCategoryKey(staffCategory), {
+          animated: false,
+          syncScroll: true,
+        });
+      }
+    }
+  }, [categoryTabs, pageWidth, requestedCategory, setKey]);
 
   const handleSelectSort = sort => {
     setSelectedSort(sort);

--- a/packages/app/src/screens/(Common)/BottomTabs/index.js
+++ b/packages/app/src/screens/(Common)/BottomTabs/index.js
@@ -67,7 +67,16 @@ const BottomTabs = () => {
           headerShown: false,
         })}>
         <Tab.Screen name="홈" component={Home} />
-        <Tab.Screen name="커뮤니티" component={Community} />
+        <Tab.Screen
+          name="커뮤니티"
+          component={Community}
+          listeners={({navigation}) => ({
+            tabPress: e => {
+              e.preventDefault();
+              navigation.navigate('커뮤니티', {tab: 'all'});
+            },
+          })}
+        />
         <Tab.Screen
           name="지도"
           component={Guesthouse}

--- a/packages/app/src/screens/(Common)/Community/CommunityStaffDetail/index.js
+++ b/packages/app/src/screens/(Common)/Community/CommunityStaffDetail/index.js
@@ -97,8 +97,6 @@ const CommunityStaffDetail = ({route}) => {
 
     navigation.navigate('ApplicantForm', {
       recruitId: recruit?.recruitId,
-      entryStartDate: recruit?.entryStartDate,
-      entryEndDate: recruit?.entryEndDate,
     });
   };
 

--- a/packages/app/src/screens/(Common)/Employ/EmployDetail/index.js
+++ b/packages/app/src/screens/(Common)/Employ/EmployDetail/index.js
@@ -101,8 +101,6 @@ const EmployDetail = ({route}) => {
                 } else {
                   navigation.navigate('ApplicantForm', {
                     recruitId: recruit?.recruitId,
-                    entryStartDate: recruit?.entryStartDate,
-                    entryEndDate: recruit?.entryEndDate,
                   });
                 }
               }}

--- a/packages/app/src/screens/(Common)/Employ/ResumeDetail/index.js
+++ b/packages/app/src/screens/(Common)/Employ/ResumeDetail/index.js
@@ -13,6 +13,9 @@ import userEmployApi from '@utils/api/userEmployApi';
 import ButtonScarlet from '@components/ButtonScarlet';
 import {parseDotDateToLocalDate} from '@utils/formatDate';
 import AlertModal from '@components/modals/AlertModal';
+import EmployExperienceModal from '@components/modals/Employ/EmployExperienceModal';
+import EmploySelfIntroModal from '@components/modals/Employ/EmploySelfIntroModal';
+import EmployTagModal from '@components/modals/Employ/EmployTagModal';
 import Loading from '@components/Loading';
 import Header from '@components/Header';
 import EmptyState from '@components/EmptyState';
@@ -40,7 +43,60 @@ const ResumeDetail = ({route}) => {
     message: '',
     buttonText: '',
   });
+  const [experienceModal, setExperienceModal] = useState({
+    visible: false,
+    editingIndex: null,
+    editingData: null,
+  });
+  const [tagModalVisible, setTagModalVisible] = useState(false);
+  const [selfIntroModalVisible, setSelfIntroModalVisible] = useState(false);
   const [newResumeSuccess, setNewResumeSuccess] = useState(false);
+
+  const handlePressFindRecruit = () => {
+    navigation.navigate('MainTabs', {
+      screen: '커뮤니티',
+      params: {tab: 'staff'},
+    });
+  };
+
+  const handleOpenAddExperience = () => {
+    setExperienceModal({
+      visible: true,
+      editingIndex: null,
+      editingData: null,
+    });
+  };
+
+  const handleOpenEditExperience = (experience, index) => {
+    setExperienceModal({
+      visible: true,
+      editingIndex: index,
+      editingData: experience,
+    });
+  };
+
+  const handleCloseExperienceModal = () => {
+    setExperienceModal(prev => ({...prev, visible: false}));
+  };
+
+  const handleApplyExperience = experience => {
+    setFormData(prev => {
+      const currentExperiences = prev.workExperience ?? [];
+      const nextExperiences =
+        experienceModal.editingIndex !== null
+          ? currentExperiences.map((item, index) =>
+              index === experienceModal.editingIndex ? experience : item,
+            )
+          : [...currentExperiences, experience];
+
+      return {...prev, workExperience: nextExperiences};
+    });
+    setExperienceModal({
+      visible: false,
+      editingIndex: null,
+      editingData: null,
+    });
+  };
 
   const tryFetchResumeById = useCallback(async () => {
     try {
@@ -127,7 +183,9 @@ const ResumeDetail = ({route}) => {
           icon={EmploySuccessIcon}
           iconSize={{width: 224, height: 171}}
           title="이력서 작성 완성!"
-          description="공고 지원하러 가볼까요?"
+          description="스탭 지원하러 가볼까요?"
+          buttonText="스탭 지원하기"
+          onPressButton={handlePressFindRecruit}
         />
       ) : (
         <ScrollView contentContainerStyle={styles.scrollContent}>
@@ -151,21 +209,19 @@ const ResumeDetail = ({route}) => {
                 setExperience={newList =>
                   setFormData(prev => ({...prev, workExperience: newList}))
                 }
+                onAddExperience={handleOpenAddExperience}
+                onEditExperience={handleOpenEditExperience}
               />
               {/* 해시태그 */}
               <ApplicantTag
                 tags={formData?.hashtags}
                 isEditable={isEditable}
-                setTags={newList =>
-                  setFormData(prev => ({...prev, hashtags: newList}))
-                }
+                onEditTags={() => setTagModalVisible(true)}
               />
               <ApplicantSelfIntroduction
                 text={formData?.selfIntro}
                 isEditable={isEditable}
-                setSelfIntro={data =>
-                  setFormData(prev => ({...prev, selfIntro: data}))
-                }
+                onEditSelfIntro={() => setSelfIntroModalVisible(true)}
               />
               {isEditable ? (
                 <View style={styles.bottomGap}>
@@ -185,6 +241,28 @@ const ResumeDetail = ({route}) => {
           )}
         </ScrollView>
       )}
+      <EmployExperienceModal
+        visible={experienceModal.visible}
+        initialData={experienceModal.editingData}
+        onClose={handleCloseExperienceModal}
+        addExperience={handleApplyExperience}
+      />
+      <EmployTagModal
+        visible={tagModalVisible}
+        onClose={() => setTagModalVisible(false)}
+        addTags={newList =>
+          setFormData(prev => ({...prev, hashtags: newList}))
+        }
+        initialData={formData?.hashtags}
+      />
+      <EmploySelfIntroModal
+        visible={selfIntroModalVisible}
+        onClose={() => setSelfIntroModalVisible(false)}
+        editSelfIntro={data =>
+          setFormData(prev => ({...prev, selfIntro: data}))
+        }
+        initialData={formData?.selfIntro}
+      />
       <AlertModal
         visible={errorModal.visible}
         title={errorModal.message}

--- a/packages/app/src/screens/(User)/Employ/ApplicantForm/index.js
+++ b/packages/app/src/screens/(User)/Employ/ApplicantForm/index.js
@@ -23,25 +23,14 @@ import {COLORS} from '@constants/colors';
 import styles from './ApplicantForm.styles';
 import useUserStore from '@stores/userStore';
 
-const parseRecruitDate = date => {
-  if (!date) {
-    return null;
-  }
-
-  return date.split('T')[0];
-};
-
 const ApplicantForm = () => {
   const navigation = useNavigation();
   const route = useRoute();
-  const {recruitId, entryStartDate = null, entryEndDate = null} =
-    route.params ?? {};
+  const {recruitId} = route.params ?? {};
 
   const [resumes, setResumes] = useState();
   const [applicant, setApplicant] = useState({
     message: '',
-    startDate: null,
-    endDate: null,
     personalInfoConsent: false,
     resumeId: null,
   });
@@ -56,26 +45,7 @@ const ApplicantForm = () => {
   const noResumeState =
     userProfile?.mbti === 'DEFAULT' ||
     userProfile?.instagramId === 'ID를 추가해주세요'; //true이면 정보 부족, false이면 이력서 없음
-
-  const tryFetchRecruitApplyDates = useCallback(async () => {
-    try {
-      const response = await userEmployApi.getRecruitById(recruitId, true);
-      const recruit = response.data;
-      setApplicant(prev => ({
-        ...prev,
-        startDate: parseRecruitDate(
-          recruit.entryStartDate ?? recruit.workStartDate,
-        ),
-        endDate: parseRecruitDate(recruit.entryEndDate ?? recruit.workEndDate),
-      }));
-    } catch (error) {
-      setErrorModal({
-        visible: true,
-        message: '공고 근무 날짜를 가져오는데 실패했습니다',
-        buttonText: '확인',
-      });
-    }
-  }, [recruitId]);
+  const hasNoResume = resumes?.length === 0;
 
   const tryFetchResumeList = useCallback(async () => {
     try {
@@ -100,22 +70,6 @@ const ApplicantForm = () => {
     setApplicant(prev => ({...prev, personalInfoConsent: allRequired}));
   }, [agreements]);
 
-  useEffect(() => {
-    const initialStartDate = parseRecruitDate(entryStartDate);
-    const initialEndDate = parseRecruitDate(entryEndDate);
-
-    if (initialStartDate && initialEndDate) {
-      setApplicant(prev => ({
-        ...prev,
-        startDate: initialStartDate,
-        endDate: initialEndDate,
-      }));
-      return;
-    }
-
-    tryFetchRecruitApplyDates();
-  }, [entryEndDate, entryStartDate, tryFetchRecruitApplyDates]);
-
   useFocusEffect(
     useCallback(() => {
       tryFetchResumeList();
@@ -127,6 +81,20 @@ const ApplicantForm = () => {
       id,
       isEditable: true,
       headerTitle: '이력서 수정',
+    });
+  };
+
+  const handleCreateResume = () => {
+    if (noResumeState) {
+      navigation.navigate('ProfileUpdate');
+      return;
+    }
+
+    navigation.navigate('ResumeDetail', {
+      isEditable: true,
+      role: 'USER',
+      isNew: true,
+      headerTitle: '이력서 작성',
     });
   };
 
@@ -145,8 +113,6 @@ const ApplicantForm = () => {
     try {
       const parsedData = {
         message: '열심히 하겠습니다.',
-        startDate: applicant.startDate,
-        endDate: applicant.endDate,
         personalInfoConsent: applicant.personalInfoConsent,
         resumeId: applicant.resumeId,
       };
@@ -177,23 +143,10 @@ const ApplicantForm = () => {
           <EmployEmpty
             title={'아직 정보가 부족해요'}
             subTitle={'이력서를 완성하러 가볼까요?'}
-            buttonText={'이력서 작성하러 가기'}
-            onPress={() => {
-              navigation.navigate('ProfileUpdate');
-            }}
           />
         ) : (
           <EmployEmpty
             title={'작성하신 이력서가 없습니다'}
-            buttonText={'이력서 작성하러 가기'}
-            onPress={() => {
-              navigation.navigate('ResumeDetail', {
-                isEditable: true,
-                role: 'USER',
-                isNew: true,
-                headerTitle: '이력서 작성',
-              });
-            }}
           />
         )
       ) : (
@@ -328,15 +281,15 @@ const ApplicantForm = () => {
 
         {/* 하단 고정 영역 */}
         <View style={styles.bottomButtonContainer}>
-          {renderPrivacyAgreement()}
+          {!hasNoResume && renderPrivacyAgreement()}
           <ButtonScarlet
-            title="지원하기"
-            onPress={handleSubmit}
+            title={hasNoResume ? '이력서 작성하기' : '지원하기'}
+            onPress={hasNoResume ? handleCreateResume : handleSubmit}
             disabled={
-              !applicant.personalInfoConsent ||
-              !applicant.resumeId ||
-              !applicant.startDate ||
-              !applicant.endDate
+              hasNoResume
+                ? false
+                : !applicant.personalInfoConsent ||
+                  !applicant.resumeId
             }
           />
         </View>

--- a/packages/app/src/screens/(User)/Employ/ApplySuccess/index.js
+++ b/packages/app/src/screens/(User)/Employ/ApplySuccess/index.js
@@ -1,4 +1,4 @@
-import {useEffect} from 'react';
+import {useCallback, useEffect} from 'react';
 import {View, Text, StyleSheet} from 'react-native';
 import {CommonActions, useNavigation} from '@react-navigation/native';
 
@@ -9,18 +9,30 @@ import {FONTS} from '@constants/fonts';
 const ApplySuccess = () => {
   const navigation = useNavigation();
 
+  const navigateStaffRecruit = useCallback(() => {
+    navigation.dispatch(
+      CommonActions.reset({
+        index: 0,
+        routes: [
+          {
+            name: 'MainTabs',
+            params: {
+              screen: '커뮤니티',
+              params: {tab: 'staff'},
+            },
+          },
+        ],
+      }),
+    );
+  }, [navigation]);
+
   useEffect(() => {
     const timer = setTimeout(() => {
-      navigation.dispatch(
-        CommonActions.reset({
-          index: 0,
-          routes: [{name: 'MainTabs', params: {screen: '홈'}}],
-        }),
-      );
+      navigateStaffRecruit();
     }, 2000);
 
     return () => clearTimeout(timer);
-  }, [navigation]);
+  }, [navigateStaffRecruit]);
 
   return (
     <View style={styles.signin}>
@@ -29,7 +41,7 @@ const ApplySuccess = () => {
           <LogoBlue width={168} />
           <View>
             <Text style={styles.titleText}>지원서 제출 완료!</Text>
-            <Text style={styles.titleText}>다른 게하들도 둘러볼까요?</Text>
+            <Text style={styles.titleText}>다른 스탭 공고도 둘러볼까요?</Text>
           </View>
         </View>
       </View>

--- a/packages/app/src/screens/(User)/UserMyPage/MyApplicantList/index.js
+++ b/packages/app/src/screens/(User)/UserMyPage/MyApplicantList/index.js
@@ -3,15 +3,15 @@ import {View, Text, FlatList, TouchableOpacity, Image} from 'react-native';
 import {useNavigation, useFocusEffect} from '@react-navigation/native';
 
 import userEmployApi from '@utils/api/userEmployApi';
-import ButtonWhite from '@components/ButtonWhite';
+// import ButtonWhite from '@components/ButtonWhite';
 import AlertModal from '@components/modals/AlertModal';
 import Header from '@components/Header';
 import EmployEmpty from '@components/Employ/EmployEmpty';
-import ResultModal from '@components/modals/ResultModal';
+// import ResultModal from '@components/modals/ResultModal';
 import {formatLocalDateToDot} from '@utils/formatDate';
 
 import styles from './MyApplicantList.styles';
-import DeleteWaLogo from '@assets/images/delete_wa.svg';
+// import DeleteWaLogo from '@assets/images/delete_wa.svg';
 
 const MyApplicantList = () => {
   const navigation = useNavigation();
@@ -24,7 +24,7 @@ const MyApplicantList = () => {
     onPress2: null,
   });
   const [loading, setLoading] = useState(true);
-  const [deleteCompleted, setDeleteCompleted] = useState(false);
+  // const [deleteCompleted, setDeleteCompleted] = useState(false);
 
   useFocusEffect(
     useCallback(() => {
@@ -51,36 +51,36 @@ const MyApplicantList = () => {
     }
   };
 
-  const tryDeleteApplicantById = async id => {
-    try {
-      await userEmployApi.deleteApply(id);
-      setDeleteCompleted(true);
-      setTimeout(() => {
-        navigation.replace('MyApplicantList');
-      }, 3000);
-    } catch (error) {
-      setErrorModal(prev => ({
-        ...prev,
-        visible: true,
-        title: '삭제 중 오류가 발생했어요',
-        buttonText: '확인',
-      }));
-    }
-  };
+  // const tryDeleteApplicantById = async id => {
+  //   try {
+  //     await userEmployApi.deleteApply(id);
+  //     setDeleteCompleted(true);
+  //     setTimeout(() => {
+  //       navigation.replace('MyApplicantList');
+  //     }, 3000);
+  //   } catch (error) {
+  //     setErrorModal(prev => ({
+  //       ...prev,
+  //       visible: true,
+  //       title: '삭제 중 오류가 발생했어요',
+  //       buttonText: '확인',
+  //     }));
+  //   }
+  // };
 
-  const handleDeleteApplicant = async id => {
-    setErrorModal({
-      visible: true,
-      title:
-        '지원 취소한 알바는\n다시 지원하기 어려워요\n알바 지원을 취소하시겠습니까?',
-      buttonText: '닫기',
-      buttonText2: '지원 취소',
-      onPress2: () => {
-        tryDeleteApplicantById(id);
-        setErrorModal(prev => ({...prev, visible: false}));
-      },
-    });
-  };
+  // const handleDeleteApplicant = async id => {
+  //   setErrorModal({
+  //     visible: true,
+  //     title:
+  //       '지원 취소한 알바는\n다시 지원하기 어려워요\n알바 지원을 취소하시겠습니까?',
+  //     buttonText: '닫기',
+  //     buttonText2: '지원 취소',
+  //     onPress2: () => {
+  //       tryDeleteApplicantById(id);
+  //       setErrorModal(prev => ({...prev, visible: false}));
+  //     },
+  //   });
+  // };
 
   const renderApplyItem = ({item}) => (
     <View>
@@ -138,10 +138,10 @@ const MyApplicantList = () => {
             </Text>
           </View>
         </TouchableOpacity>
-        <ButtonWhite
+        {/* <ButtonWhite
           title={'지원 취소하기'}
           onPress={() => handleDeleteApplicant(item.id)}
-        />
+        /> */}
       </View>
       <View style={styles.divider} />
     </View>
@@ -177,14 +177,14 @@ const MyApplicantList = () => {
         onPress2={errorModal.onPress2}
         title={errorModal.title}
       />
-      <ResultModal
+      {/* <ResultModal
         visible={deleteCompleted}
         onClose={() => {
           setDeleteCompleted(false);
         }}
         title="알바 지원을 취소했어요"
         Icon={DeleteWaLogo}
-      />
+      /> */}
     </View>
   );
 };


### PR DESCRIPTION
## 작업 내용

### 스탭 지원 흐름 개선
- 이력서가 없는 상태에서 지원 시 약관 동의 영역을 숨기고 `이력서 작성하기` 버튼을 노출했습니다.
- 지원 요청 payload에서 희망 근무 시작일/종료일을 제거했습니다.
- 지원 완료 후 홈이 아닌 `커뮤니티 > 스탭` 화면으로 이동하도록 변경했습니다.
- 이력서 작성 완료 화면에 `스탭 지원하기` 버튼을 추가했습니다.

### 커뮤니티 스탭 진입 처리
- 이력서 작성 완료/지원 완료처럼 명시적으로 스탭 이동이 필요한 경우 `tab: staff`로 진입하도록 처리했습니다.
- 하단 메뉴에서 커뮤니티를 누르는 경우에는 `전체` 카테고리로 진입하도록 분리했습니다.

### Android 이력서 작성 모달 개선
- Android에서 경력/태그/자기소개 모달이 화면 내부에 끼어 보이던 문제를 수정했습니다.
- 경력/태그/자기소개 모달을 이력서 상세 화면 루트에서 관리하도록 구조를 변경했습니다.
- 경력/자기소개 모달 높이를 태그 모달과 동일하게 맞췄습니다.

### 이력서 자기소개 제한 변경
- 자기소개 글자 수 제한을 50,000자에서 1,000자로 변경했습니다.
- 자기소개 글자 수 표시도 `/1,000`으로 수정했습니다.

### 지원 취소 버튼 비활성화
- 지원 현황 화면에서 `지원 취소하기` 버튼과 관련 동작을 주석 처리했습니다.

## 테스트

- 이력서 작성 화면에서 경력/태그/자기소개 모달이 iOS/Android에서 정상 노출되는지 확인
- 이력서가 없는 상태에서 지원 시 `이력서 작성하기` 버튼 노출 확인
- 지원 완료 후 `커뮤니티 > 스탭` 이동 확인
- 하단 메뉴 커뮤니티 진입 시 `전체` 카테고리 진입 확인
- `npm run build:web` 성공
- 변경 파일 ESLint 확인 완료
