### PR TITLE
chore: migrate traveler web domain

### DIFF
--- a/apps/web/dist/app-ads.txt
+++ b/apps/web/dist/app-ads.txt
@@ -1,0 +1,1 @@
+google.com, pub-6098454400067335, DIRECT, f08c47fec0942fa0

--- a/apps/web/dist/index.html
+++ b/apps/web/dist/index.html
@@ -21,7 +21,7 @@
       property="og:description"
       content="게스트하우스 숙박 예약부터 파티·체험 콘텐츠 신청까지 게딱지에서 한 번에 확인해 보세요."
     />
-    <meta property="og:url" content="https://app.ddakji.kr/" />
+    <meta property="og:url" content="https://ddakji.kr/" />
 
     <meta name="twitter:card" content="summary" />
     <meta name="twitter:title" content="게딱지 | 게스트하우스 예약·콘텐츠 플랫폼" />
@@ -29,7 +29,7 @@
       name="twitter:description"
       content="게스트하우스 숙박 예약과 파티·체험 콘텐츠 신청을 한곳에서 확인해 보세요."
     />
-    <meta name="twitter:domain" content="app.ddakji.kr" />
+    <meta name="twitter:domain" content="ddakji.kr" />
     <link rel="icon" type="image/svg+xml" href="/favicon-app.svg" />
     <title>게딱지(게스트하우스 딱, 지금!)</title>
     <!-- Temporarily disabled web ads.

--- a/apps/web/dist/robots.txt
+++ b/apps/web/dist/robots.txt
@@ -1,4 +1,4 @@
 User-agent: *
 Allow: /
 
-Sitemap: https://app.ddakji.kr/sitemap.xml
+Sitemap: https://ddakji.kr/sitemap.xml

--- a/apps/web/dist/sitemap.xml
+++ b/apps/web/dist/sitemap.xml
@@ -1,15 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
-    <loc>https://app.ddakji.kr/</loc>
+    <loc>https://ddakji.kr/</loc>
   </url>
   <url>
-    <loc>https://app.ddakji.kr/guesthouses</loc>
+    <loc>https://ddakji.kr/about</loc>
   </url>
   <url>
-    <loc>https://app.ddakji.kr/contents</loc>
+    <loc>https://ddakji.kr/guesthouses</loc>
   </url>
   <url>
-    <loc>https://app.ddakji.kr/community</loc>
+    <loc>https://ddakji.kr/contents</loc>
+  </url>
+  <url>
+    <loc>https://ddakji.kr/community</loc>
   </url>
 </urlset>

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -21,7 +21,7 @@
       property="og:description"
       content="게스트하우스 숙박 예약부터 파티·체험 콘텐츠 신청까지 게딱지에서 한 번에 확인해 보세요."
     />
-    <meta property="og:url" content="https://app.ddakji.kr/" />
+    <meta property="og:url" content="https://ddakji.kr/" />
 
     <meta name="twitter:card" content="summary" />
     <meta name="twitter:title" content="게딱지 | 게스트하우스 예약·콘텐츠 플랫폼" />
@@ -29,7 +29,7 @@
       name="twitter:description"
       content="게스트하우스 숙박 예약과 파티·체험 콘텐츠 신청을 한곳에서 확인해 보세요."
     />
-    <meta name="twitter:domain" content="app.ddakji.kr" />
+    <meta name="twitter:domain" content="ddakji.kr" />
     <link rel="icon" type="image/svg+xml" href="/favicon-app.svg" />
     <title>게딱지(게스트하우스 딱, 지금!)</title>
     <!-- Google tag (gtag.js) - web only -->

--- a/apps/web/public/app-ads.txt
+++ b/apps/web/public/app-ads.txt
@@ -1,0 +1,1 @@
+google.com, pub-6098454400067335, DIRECT, f08c47fec0942fa0

--- a/apps/web/public/robots.txt
+++ b/apps/web/public/robots.txt
@@ -1,4 +1,4 @@
 User-agent: *
 Allow: /
 
-Sitemap: https://app.ddakji.kr/sitemap.xml
+Sitemap: https://ddakji.kr/sitemap.xml

--- a/apps/web/public/sitemap.xml
+++ b/apps/web/public/sitemap.xml
@@ -1,15 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
-    <loc>https://app.ddakji.kr/</loc>
+    <loc>https://ddakji.kr/</loc>
   </url>
   <url>
-    <loc>https://app.ddakji.kr/guesthouses</loc>
+    <loc>https://ddakji.kr/about</loc>
   </url>
   <url>
-    <loc>https://app.ddakji.kr/contents</loc>
+    <loc>https://ddakji.kr/guesthouses</loc>
   </url>
   <url>
-    <loc>https://app.ddakji.kr/community</loc>
+    <loc>https://ddakji.kr/contents</loc>
+  </url>
+  <url>
+    <loc>https://ddakji.kr/community</loc>
   </url>
 </urlset>


### PR DESCRIPTION
## 변경 사항

- 여행자 웹 SEO 도메인을 `app.ddakji.kr`에서 `ddakji.kr`로 변경
- robots.txt 및 sitemap.xml 경로 변경
- sitemap에 `/about` 추가
- `app-ads.txt` 정적 파일 추가

## 테스트

- `npm run build:web` 성공
- `app.ddakji.kr` 잔여 참조 없음